### PR TITLE
Posibility to build in docker container.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,30 @@ Is possible to use a micro-ROS Agent just with this docker command:
 docker run -it --rm --net=host microros/micro-ros-agent:foxy udp4 --port 8888 -v6
 ```
 
+## Build with docker container
+
+It's possible to build this example application using preconfigured docker container. 
+
+1. Execute script to build an example app using docker container
+
+```bash
+./build_in_container.sh
+```
+
+Docker image microros/esp-idf-microros:latest will be automatically pulled from hub.docker.com
+and used to build an application.
+
+After build is finished build results will be accessible in a local ./build directory. 
+
+Dockerfile for this container is provided in the ./docker directory.
+
+2. Use you standart way to flash binaries to esp32
+
+For example, using esptool
+
+```bash
+esptool.py --chip esp32 -p <COM3> -b 460800 --before=default_reset --after=hard_reset write_flash --flash_mode dio --flash_freq 40m --flash_size 2MB 0x8000 ./build/partition_table/partition-table.bin 0x1000 ./build/bootloader/bootloader.bin 0x10000 ./build/micro_ros_idf.bin 
+```
 ## Using serial transport
 
 By default, micro-ROS component uses UDP transport, but is possible to enable UART transport setting the `colcon.meta` like:

--- a/README.md
+++ b/README.md
@@ -40,12 +40,10 @@ docker run -it --rm --net=host microros/micro-ros-agent:foxy udp4 --port 8888 -v
 
 ## Build with docker container
 
-It's possible to build this example application using preconfigured docker container. 
-
-1. Execute script to build an example app using docker container
+It's possible to build this example application using preconfigured docker container. Execute this line to build an example app using docker container:
 
 ```bash
-./build_in_container.sh
+docker run -it --rm --user espidf --volume="/etc/timezone:/etc/timezone:ro" -v  $(pwd):$(pwd) --workdir $(pwd) microros/esp-idf-microros:latest /bin/bash  -c "idf.py build &&"
 ```
 
 Docker image microros/esp-idf-microros:latest will be automatically pulled from hub.docker.com
@@ -55,13 +53,6 @@ After build is finished build results will be accessible in a local ./build dire
 
 Dockerfile for this container is provided in the ./docker directory.
 
-2. Use you standart way to flash binaries to esp32
-
-For example, using esptool
-
-```bash
-esptool.py --chip esp32 -p <COM3> -b 460800 --before=default_reset --after=hard_reset write_flash --flash_mode dio --flash_freq 40m --flash_size 2MB 0x8000 ./build/partition_table/partition-table.bin 0x1000 ./build/bootloader/bootloader.bin 0x10000 ./build/micro_ros_idf.bin 
-```
 ## Using serial transport
 
 By default, micro-ROS component uses UDP transport, but is possible to enable UART transport setting the `colcon.meta` like:

--- a/build_in_container.sh
+++ b/build_in_container.sh
@@ -1,0 +1,2 @@
+#/bin/bash
+docker run -it --rm --user espidf --volume="/etc/timezone:/etc/timezone:ro" -v  $(pwd):$(pwd) --workdir $(pwd) microros/esp-idf-microros:latest /bin/bash  -c "idf.py build &&"

--- a/build_in_container.sh
+++ b/build_in_container.sh
@@ -1,2 +1,0 @@
-#/bin/bash
-docker run -it --rm --user espidf --volume="/etc/timezone:/etc/timezone:ro" -v  $(pwd):$(pwd) --workdir $(pwd) microros/esp-idf-microros:latest /bin/bash  -c "idf.py build &&"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,29 @@
+
+
+FROM espressif/idf:release-v4.1
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN echo "Set disable_coredump false" >> /etc/sudo.conf
+RUN apt update -q && \
+    apt install -yq sudo lsb-release gosu nano && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG TZ_ARG=UTC
+ENV TZ=$TZ_ARG
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+
+COPY ./install_micro_ros_deps_script.sh /install_micro_ros_deps_script.sh
+
+RUN mkdir -p /tmp/install_micro_ros_deps_script && mv /install_micro_ros_deps_script.sh /tmp/install_micro_ros_deps_script/ && \
+    /tmp/install_micro_ros_deps_script/install_micro_ros_deps_script.sh && \
+    rm -rf /var/lib/apt/lists/*
+	
+ARG USER_ID=espidf
+
+RUN useradd --create-home --home-dir /home/$USER_ID --shell /bin/bash --user-group --groups adm,sudo $USER_ID && \
+    echo $USER_ID:$USER_ID | chpasswd && \
+    echo "$USER_ID ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+ARG USER_ID
+USER $USER_ID

--- a/docker/install_micro_ros_deps_script.sh
+++ b/docker/install_micro_ros_deps_script.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -eu
+
+sh -c 'echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list'
+sudo curl -s https://raw.githubusercontent.com/ros/rosdistro/master/ros.asc | sudo apt-key add - 
+sudo apt update -q
+sudo apt install -yq python3-colcon-common-extensions
+source $IDF_PATH/export.sh
+pip3 install catkin_pkg lark-parser empy
+
+set +u


### PR DESCRIPTION
Hi,

This pull requst add posibility to build this example microros app using preconfigured docker container
with esp-idf sdk and microros component build dependencies.

It contains Dockerfile, application build script and updated README.md.
In the description I assume that docker image will be built by you 
and pushed to hub.docker.com as microros/esp-idf-microros:latest image. 

Regards,
Dmitry Ryzhov