### PR TITLE
make: added -j to enable parallel build jobs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ externalproject_add(libmicroros_project
     BINARY_DIR ${COMPONENT_DIR}
     CONFIGURE_COMMAND ""
     BUILD_COMMAND
-        ${submake} -f libmicroros.mk
+        ${submake} -j -f libmicroros.mk
             CC=${CMAKE_C_COMPILER}
             AR=${CMAKE_AR}
             CFLAGS=${CMAKE_C_FLAGS}


### PR DESCRIPTION
The micro-ROS stack is compiled by the esp-IDF as an external project based on make, since the build involve building multiple subprojects I added the -j option to tell the make to use parallel build jobs when possible.

When a parallel build job is available, make will assign an ideal number of threads to parallelize the build process improving the speed, especially in the first build.