### PR TITLE
feature/ethernet: Enable support of the microROS over the ethernet interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,6 @@
-idf_component_register(SRCS "")
+idf_component_register(SRCS "network_interfaces/uros_ethernet_netif.c" "network_interfaces/uros_wlan_netif.c"
+                       INCLUDE_DIRS "network_interfaces"
+                       REQUIRES nvs_flash)
 
 if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
 set(submake "$(MAKE)")

--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -18,6 +18,14 @@ config MICRO_ROS_AGENT_PORT
     help
         micro-ROS Agent port.
 
+choice  
+    prompt "micro-ROS network interface select"
+    config  MICRO_ROS_ESP_NETIF_WLAN
+        bool "micro-ROS uses WLAN netif"
+    config  MICRO_ROS_ESP_NETIF_ENET
+        bool "micro-ROS uses Ethernet netif"
+endchoice
+    
 menu "UART Settings (for serial transport)"
 
 config MICROROS_UART_TXD
@@ -53,18 +61,21 @@ endmenu
 menu "WiFi Configuration"
 
     config ESP_WIFI_SSID
+        depends on MICRO_ROS_ESP_NETIF_WLAN
         string "WiFi SSID"
         default "myssid"
         help
             SSID (network name) for the example to connect to.
 
     config ESP_WIFI_PASSWORD
+        depends on MICRO_ROS_ESP_NETIF_WLAN
         string "WiFi Password"
         default "mypassword"
         help
             WiFi password (WPA or WPA2) for the example to use.
 
     config ESP_MAXIMUM_RETRY
+        depends on MICRO_ROS_ESP_NETIF_WLAN
         int "Maximum retry"
         default 5
         help

--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -21,9 +21,9 @@ config MICRO_ROS_AGENT_PORT
 choice  
     prompt "micro-ROS network interface select"
     config  MICRO_ROS_ESP_NETIF_WLAN
-        bool "micro-ROS uses WLAN netif"
+        bool "micro-ROS over network uses WLAN netif"
     config  MICRO_ROS_ESP_NETIF_ENET
-        bool "micro-ROS uses Ethernet netif"
+        bool "micro-ROS over network uses Ethernet netif"
 endchoice
     
 menu "UART Settings (for serial transport)"
@@ -58,24 +58,172 @@ config MICROROS_UART_CTS
 
 endmenu
 
+menu "Ethernet Configuration"
+    config MICRO_ROS_USE_SPI_ETHERNET
+        bool
+
+    choice MICRO_ROS_ETHERNET_TYPE
+        prompt "Ethernet Type"
+        default MICRO_ROS_USE_INTERNAL_ETHERNET if IDF_TARGET_ESP32
+        default MICRO_ROS_USE_W5500
+        help
+            Select which kind of Ethernet will be used in the example.
+
+        config MICRO_ROS_USE_INTERNAL_ETHERNET
+            depends on IDF_TARGET_ESP32
+            select ETH_USE_ESP32_EMAC
+            bool "Internal EMAC"
+            help
+                Select internal Ethernet MAC controller.
+
+        config MICRO_ROS_USE_DM9051
+            bool "DM9051 Module"
+            select MICRO_ROS_USE_SPI_ETHERNET
+            select ETH_USE_SPI_ETHERNET
+            select ETH_SPI_ETHERNET_DM9051
+            help
+                Select external SPI-Ethernet module (DM9051).
+
+        config MICRO_ROS_USE_W5500
+            bool "W5500 Module"
+            select MICRO_ROS_USE_SPI_ETHERNET
+            select ETH_USE_SPI_ETHERNET
+            select ETH_SPI_ETHERNET_W5500
+            help
+                Select external SPI-Ethernet module (W5500).
+    endchoice # MICRO_ROS_ETHERNET_TYPE
+
+    if MICRO_ROS_USE_INTERNAL_ETHERNET
+        choice MICRO_ROS_ETH_PHY_MODEL
+            prompt "Ethernet PHY Device"
+            default MICRO_ROS_ETH_PHY_IP101
+            help
+                Select the Ethernet PHY device to use in the example.
+
+            config MICRO_ROS_ETH_PHY_IP101
+                bool "IP101"
+                help
+                    IP101 is a single port 10/100 MII/RMII/TP/Fiber Fast Ethernet Transceiver.
+                    Goto http://www.icplus.com.tw/pp-IP101G.html for more information about it.
+
+            config MICRO_ROS_ETH_PHY_RTL8201
+                bool "RTL8201/SR8201"
+                help
+                    RTL8201F/SR8201F is a single port 10/100Mb Ethernet Transceiver with auto MDIX.
+                    Goto http://www.corechip-sz.com/productsview.asp?id=22 for more information about it.
+
+            config MICRO_ROS_ETH_PHY_LAN8720
+                bool "LAN8720"
+                help
+                    LAN8720A is a small footprint RMII 10/100 Ethernet Transceiver with HP Auto-MDIX Support.
+                    Goto https://www.microchip.com/LAN8720A for more information about it.
+
+            config MICRO_ROS_ETH_PHY_DP83848
+                bool "DP83848"
+                help
+                    DP83848 is a single port 10/100Mb/s Ethernet Physical Layer Transceiver.
+                    Goto http://www.ti.com/product/DP83848J for more information about it.
+
+            config MICRO_ROS_ETH_PHY_KSZ8041
+                bool "KSZ8041"
+                help
+                    The KSZ8041 is a single supply 10Base-T/100Base-TX Physical Layer Transceiver.
+                    Goto https://www.microchip.com/wwwproducts/en/KSZ8041 for more information about it.
+        endchoice # MICRO_ROS_ETH_PHY_MODEL
+
+        config MICRO_ROS_ETH_MDC_GPIO
+            int "SMI MDC GPIO number"
+            default 23
+            help
+                Set the GPIO number used by SMI MDC.
+
+        config MICRO_ROS_ETH_MDIO_GPIO
+            int "SMI MDIO GPIO number"
+            default 18
+            help
+                Set the GPIO number used by SMI MDIO.
+    endif # MICRO_ROS_USE_INTERNAL_ETHERNET
+
+    if MICRO_ROS_USE_SPI_ETHERNET
+        config MICRO_ROS_ETH_SPI_HOST
+            int "SPI Host Number"
+            range 0 2
+            default 1
+            help
+                Set the SPI host used to communicate with the SPI Ethernet Controller.
+
+        config MICRO_ROS_ETH_SPI_SCLK_GPIO
+            int "SPI SCLK GPIO number"
+            range 0 33
+            default 20
+            help
+                Set the GPIO number used by SPI SCLK.
+
+        config MICRO_ROS_ETH_SPI_MOSI_GPIO
+            int "SPI MOSI GPIO number"
+            range 0 33
+            default 19
+            help
+                Set the GPIO number used by SPI MOSI.
+
+        config MICRO_ROS_ETH_SPI_MISO_GPIO
+            int "SPI MISO GPIO number"
+            range 0 33
+            default 18
+            help
+                Set the GPIO number used by SPI MISO.
+
+        config MICRO_ROS_ETH_SPI_CS_GPIO
+            int "SPI CS GPIO number"
+            range 0 33
+            default 21
+            help
+                Set the GPIO number used by SPI CS.
+
+        config MICRO_ROS_ETH_SPI_CLOCK_MHZ
+            int "SPI clock speed (MHz)"
+            range 5 80
+            default 36
+            help
+                Set the clock speed (MHz) of SPI interface.
+
+        config MICRO_ROS_ETH_SPI_INT_GPIO
+            int "Interrupt GPIO number"
+            default 4
+            help
+                Set the GPIO number used by the SPI Ethernet module interrupt line.
+    endif # MICRO_ROS_USE_SPI_ETHERNET
+
+    config MICRO_ROS_ETH_PHY_RST_GPIO
+        int "PHY Reset GPIO number"
+        default 5
+        help
+            Set the GPIO number used to reset PHY chip.
+            Set to -1 to disable PHY chip hardware reset.
+
+    config MICRO_ROS_ETH_PHY_ADDR
+        int "PHY Address"
+        range 0 31
+        default 1
+        help
+            Set PHY address according your board schematic.
+endmenu
+
 menu "WiFi Configuration"
 
     config ESP_WIFI_SSID
-        depends on MICRO_ROS_ESP_NETIF_WLAN
         string "WiFi SSID"
         default "myssid"
         help
             SSID (network name) for the example to connect to.
 
     config ESP_WIFI_PASSWORD
-        depends on MICRO_ROS_ESP_NETIF_WLAN
         string "WiFi Password"
         default "mypassword"
         help
             WiFi password (WPA or WPA2) for the example to use.
 
     config ESP_MAXIMUM_RETRY
-        depends on MICRO_ROS_ESP_NETIF_WLAN
         int "Maximum retry"
         default 5
         help

--- a/examples/int32_publisher/main/main.c
+++ b/examples/int32_publisher/main/main.c
@@ -1,125 +1,27 @@
+#include <string.h>
+
 #include "uxr/client/config.h"
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 
+#include "esp_log.h"
+#include "esp_system.h"
+
 #include <driver/uart.h>
 #include <driver/gpio.h>
 
-#include <string.h>
-#include "freertos/event_groups.h"
-#include "esp_system.h"
-#include "esp_wifi.h"
-#include "esp_event.h"
-#include "esp_log.h"
-#include "esp_system.h"
-#include "nvs_flash.h"
+#include <uros_network_interfaces.h>
 
-#include "lwip/err.h"
-#include "lwip/sys.h"
-
-void appMain(void *argument);
-
-#define ESP_WIFI_SSID      CONFIG_ESP_WIFI_SSID
-#define ESP_WIFI_PASS      CONFIG_ESP_WIFI_PASSWORD
-#define ESP_MAXIMUM_RETRY  CONFIG_ESP_MAXIMUM_RETRY
-
-static EventGroupHandle_t s_wifi_event_group;
-
-#define WIFI_CONNECTED_BIT BIT0
-#define WIFI_FAIL_BIT      BIT1
-
-static const char *TAG = "wifi station";
-static int s_retry_num = 0;
-
-static void event_handler(void* arg, esp_event_base_t event_base,
-                                int32_t event_id, void* event_data)
-{
-    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
-        esp_wifi_connect();
-    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
-        if (s_retry_num < ESP_MAXIMUM_RETRY) {
-            esp_wifi_connect();
-            s_retry_num++;
-            ESP_LOGI(TAG, "retry to connect to the AP");
-        } else {
-            xEventGroupSetBits(s_wifi_event_group, WIFI_FAIL_BIT);
-        }
-        ESP_LOGI(TAG,"connect to the AP fail");
-    } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
-        ip_event_got_ip_t* event = (ip_event_got_ip_t*) event_data;
-        ESP_LOGI(TAG, "got ip:" IPSTR, IP2STR(&event->ip_info.ip));
-        s_retry_num = 0;
-        xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
-    }
-}
-
-void wifi_init_sta()
-{
-    s_wifi_event_group = xEventGroupCreate();
-
-    ESP_ERROR_CHECK(esp_netif_init());
-
-    ESP_ERROR_CHECK(esp_event_loop_create_default());
-    esp_netif_create_default_wifi_sta();
-
-    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
-    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
-
-    ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &event_handler, NULL));
-    ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, &event_handler, NULL));
-
-    wifi_config_t wifi_config = {
-        .sta = {
-            .ssid = ESP_WIFI_SSID,
-            .password = ESP_WIFI_PASS
-        },
-    };
-    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA) );
-    ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config) );
-    ESP_ERROR_CHECK(esp_wifi_start() );
-
-    ESP_LOGI(TAG, "wifi_init_sta finished.");
-
-    /* Waiting until either the connection is established (WIFI_CONNECTED_BIT) or connection failed for the maximum
-     * number of re-tries (WIFI_FAIL_BIT). The bits are set by event_handler() (see above) */
-    EventBits_t bits = xEventGroupWaitBits(s_wifi_event_group,
-            WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
-            pdFALSE,
-            pdFALSE,
-            portMAX_DELAY);
-
-    /* xEventGroupWaitBits() returns the bits before the call returned, hence we can test which event actually
-     * happened. */
-    if (bits & WIFI_CONNECTED_BIT) {
-        ESP_LOGI(TAG, "connected to ap SSID:%s", ESP_WIFI_SSID);
-    } else if (bits & WIFI_FAIL_BIT) {
-        ESP_LOGI(TAG, "Failed to connect to SSID:%s", ESP_WIFI_SSID);
-    } else {
-        ESP_LOGE(TAG, "UNEXPECTED EVENT");
-    }
-
-    ESP_ERROR_CHECK(esp_event_handler_unregister(IP_EVENT, IP_EVENT_STA_GOT_IP, &event_handler));
-    ESP_ERROR_CHECK(esp_event_handler_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, &event_handler));
-    vEventGroupDelete(s_wifi_event_group);
-}
+extern void appMain(void *argument);
 
 void app_main(void)
 {   
-    // Start networkign if required
 #ifdef UCLIENT_PROFILE_UDP
-    //Initialize NVS
-    esp_err_t ret = nvs_flash_init();
-    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
-      ESP_ERROR_CHECK(nvs_flash_erase());
-      ret = nvs_flash_init();
-    }
-    ESP_ERROR_CHECK(ret);
-
-    ESP_LOGI(TAG, "ESP_WIFI_MODE_STA");
-    wifi_init_sta();
+    // Start the networking if required
+    ESP_ERROR_CHECK(uros_network_interface_initialize());
 #endif  // UCLIENT_PROFILE_UDP
 
-    // start microROS task
+    //start microROS task
     xTaskCreate(appMain, "uros_task", CONFIG_MICRO_ROS_APP_STACK, NULL, 5, NULL);
 }

--- a/examples/int32_publisher/main/rclc_int32_publisher.c
+++ b/examples/int32_publisher/main/rclc_int32_publisher.c
@@ -38,7 +38,7 @@ void appMain(void * arg)
 	rmw_init_options_t* rmw_options = rcl_init_options_get_rmw_init_options(&init_options);
 
 	// Static Agent IP and port can be used instead of autodisvery.
-	 RCCHECK(rmw_uros_options_set_udp_address("192.168.0.197", "8888", rmw_options));
+	RCCHECK(rmw_uros_options_set_udp_address(CONFIG_MICRO_ROS_AGENT_IP, CONFIG_MICRO_ROS_AGENT_PORT, rmw_options));
 	//RCCHECK(rmw_uros_discover_agent(rmw_options));
 
 	// create init_options
@@ -77,8 +77,8 @@ void appMain(void * arg)
 	}
 
 	// free resources
-	RCCHECK(rcl_publisher_fini(&publisher, &node))
-	RCCHECK(rcl_node_fini(&node))
+	RCCHECK(rcl_publisher_fini(&publisher, &node));
+	RCCHECK(rcl_node_fini(&node));
 
   	vTaskDelete(NULL);
 }

--- a/examples/int32_publisher/main/rclc_int32_publisher.c
+++ b/examples/int32_publisher/main/rclc_int32_publisher.c
@@ -38,8 +38,8 @@ void appMain(void * arg)
 	rmw_init_options_t* rmw_options = rcl_init_options_get_rmw_init_options(&init_options);
 
 	// Static Agent IP and port can be used instead of autodisvery.
-	// RCCHECK(rmw_uros_options_set_udp_address(CONFIG_MICRO_ROS_AGENT_IP, CONFIG_MICRO_ROS_AGENT_PORT, rmw_options));
-	RCCHECK(rmw_uros_discover_agent(rmw_options));
+	 RCCHECK(rmw_uros_options_set_udp_address("192.168.0.197", "8888", rmw_options));
+	//RCCHECK(rmw_uros_discover_agent(rmw_options));
 
 	// create init_options
 	RCCHECK(rclc_support_init_with_options(&support, 0, NULL, &init_options, &allocator));

--- a/network_interfaces/uros_ethernet_netif.c
+++ b/network_interfaces/uros_ethernet_netif.c
@@ -1,0 +1,157 @@
+#include <stdio.h>
+#include <string.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_netif.h"
+#include "esp_eth.h"
+#include "esp_event.h"
+#include "esp_log.h"
+#include "driver/gpio.h"
+#include "sdkconfig.h"
+#if CONFIG_ETH_USE_SPI_ETHERNET
+#include "driver/spi_master.h"
+#endif 
+#include "uros_network_interfaces.h"
+
+#ifdef CONFIG_MICRO_ROS_ESP_NETIF_ENET
+
+static const char *TAG = "eth_interface";
+
+static void eth_event_handler(void *arg, esp_event_base_t event_base,
+                              int32_t event_id, void *event_data)
+{
+    uint8_t mac_addr[6] = {0};
+    /* we can get the ethernet driver handle from event data */
+    esp_eth_handle_t eth_handle = *(esp_eth_handle_t *)event_data;
+
+    switch (event_id) {
+    case ETHERNET_EVENT_CONNECTED:
+        esp_eth_ioctl(eth_handle, ETH_CMD_G_MAC_ADDR, mac_addr);
+        ESP_LOGI(TAG, "Ethernet Link Up");
+        ESP_LOGI(TAG, "Ethernet HW Addr %02x:%02x:%02x:%02x:%02x:%02x",
+                 mac_addr[0], mac_addr[1], mac_addr[2], mac_addr[3], mac_addr[4], mac_addr[5]);
+        break;
+    case ETHERNET_EVENT_DISCONNECTED:
+        ESP_LOGI(TAG, "Ethernet Link Down");
+        break;
+    case ETHERNET_EVENT_START:
+        ESP_LOGI(TAG, "Ethernet Started");
+        break;
+    case ETHERNET_EVENT_STOP:
+        ESP_LOGI(TAG, "Ethernet Stopped");
+        break;
+    default:
+        break;
+    }
+}
+
+static void got_ip_event_handler(void *arg, esp_event_base_t event_base,
+                                 int32_t event_id, void *event_data)
+{
+    ip_event_got_ip_t *event = (ip_event_got_ip_t *) event_data;
+    const esp_netif_ip_info_t *ip_info = &event->ip_info;
+
+    ESP_LOGI(TAG, "Ethernet Got IP Address");
+    ESP_LOGI(TAG, "~~~~~~~~~~~");
+    ESP_LOGI(TAG, "ETHIP:" IPSTR, IP2STR(&ip_info->ip));
+    ESP_LOGI(TAG, "ETHMASK:" IPSTR, IP2STR(&ip_info->netmask));
+    ESP_LOGI(TAG, "ETHGW:" IPSTR, IP2STR(&ip_info->gw));
+    ESP_LOGI(TAG, "~~~~~~~~~~~");
+}
+
+esp_err_t uros_network_interface_initialize(void)
+{
+    // Initialize TCP/IP network interface (should be called only once in application)
+    ESP_ERROR_CHECK(esp_netif_init());
+    // Create default event loop that running in background
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+    esp_netif_config_t cfg = ESP_NETIF_DEFAULT_ETH();
+    esp_netif_t *eth_netif = esp_netif_new(&cfg);
+    // Set default handlers to process TCP/IP stuffs
+    ESP_ERROR_CHECK(esp_eth_set_default_handlers(eth_netif));
+    // Register user defined event handers
+    ESP_ERROR_CHECK(esp_event_handler_register(ETH_EVENT, ESP_EVENT_ANY_ID, &eth_event_handler, NULL));
+    ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_ETH_GOT_IP, &got_ip_event_handler, NULL));
+
+    eth_mac_config_t mac_config = ETH_MAC_DEFAULT_CONFIG();
+    eth_phy_config_t phy_config = ETH_PHY_DEFAULT_CONFIG();
+    phy_config.phy_addr = CONFIG_MICRO_ROS_ETH_PHY_ADDR;
+    phy_config.reset_gpio_num = CONFIG_MICRO_ROS_ETH_PHY_RST_GPIO;
+#if CONFIG_MICRO_ROS_USE_INTERNAL_ETHERNET
+    mac_config.smi_mdc_gpio_num = CONFIG_MICRO_ROS_ETH_MDC_GPIO;
+    mac_config.smi_mdio_gpio_num = CONFIG_MICRO_ROS_ETH_MDIO_GPIO;
+    esp_eth_mac_t *mac = esp_eth_mac_new_esp32(&mac_config);
+#if CONFIG_MICRO_ROS_ETH_PHY_IP101
+    esp_eth_phy_t *phy = esp_eth_phy_new_ip101(&phy_config);
+#elif CONFIG_MICRO_ROS_ETH_PHY_RTL8201
+    esp_eth_phy_t *phy = esp_eth_phy_new_rtl8201(&phy_config);
+#elif CONFIG_MICRO_ROS_ETH_PHY_LAN8720
+    esp_eth_phy_t *phy = esp_eth_phy_new_lan8720(&phy_config);
+#elif CONFIG_MICRO_ROS_ETH_PHY_DP83848
+    esp_eth_phy_t *phy = esp_eth_phy_new_dp83848(&phy_config);
+#elif CONFIG_MICRO_ROS_ETH_PHY_KSZ8041
+    esp_eth_phy_t *phy = esp_eth_phy_new_ksz8041(&phy_config);
+#endif
+#elif CONFIG_ETH_USE_SPI_ETHERNET
+    gpio_install_isr_service(0);
+    spi_device_handle_t spi_handle = NULL;
+    spi_bus_config_t buscfg = {
+        .miso_io_num = CONFIG_MICRO_ROS_ETH_SPI_MISO_GPIO,
+        .mosi_io_num = CONFIG_MICRO_ROS_ETH_SPI_MOSI_GPIO,
+        .sclk_io_num = CONFIG_MICRO_ROS_ETH_SPI_SCLK_GPIO,
+        .quadwp_io_num = -1,
+        .quadhd_io_num = -1,
+    };
+    ESP_ERROR_CHECK(spi_bus_initialize(CONFIG_MICRO_ROS_ETH_SPI_HOST, &buscfg, 1));
+#if CONFIG_MICRO_ROS_USE_DM9051
+    spi_device_interface_config_t devcfg = {
+        .command_bits = 1,
+        .address_bits = 7,
+        .mode = 0,
+        .clock_speed_hz = CONFIG_MICRO_ROS_ETH_SPI_CLOCK_MHZ * 1000 * 1000,
+        .spics_io_num = CONFIG_MICRO_ROS_ETH_SPI_CS_GPIO,
+        .queue_size = 20
+    };
+    ESP_ERROR_CHECK(spi_bus_add_device(CONFIG_MICRO_ROS_ETH_SPI_HOST, &devcfg, &spi_handle));
+    /* dm9051 ethernet driver is based on spi driver */
+    eth_dm9051_config_t dm9051_config = ETH_DM9051_DEFAULT_CONFIG(spi_handle);
+    dm9051_config.int_gpio_num = CONFIG_MICRO_ROS_ETH_SPI_INT_GPIO;
+    esp_eth_mac_t *mac = esp_eth_mac_new_dm9051(&dm9051_config, &mac_config);
+    esp_eth_phy_t *phy = esp_eth_phy_new_dm9051(&phy_config);
+#elif CONFIG_MICRO_ROS_USE_W5500
+    spi_device_interface_config_t devcfg = {
+        .command_bits = 16, // Actually it's the address phase in W5500 SPI frame
+        .address_bits = 8,  // Actually it's the control phase in W5500 SPI frame
+        .mode = 0,
+        .clock_speed_hz = CONFIG_MICRO_ROS_ETH_SPI_CLOCK_MHZ * 1000 * 1000,
+        .spics_io_num = CONFIG_MICRO_ROS_ETH_SPI_CS_GPIO,
+        .queue_size = 20
+    };
+    ESP_ERROR_CHECK(spi_bus_add_device(CONFIG_MICRO_ROS_ETH_SPI_HOST, &devcfg, &spi_handle));
+    /* w5500 ethernet driver is based on spi driver */
+    eth_w5500_config_t w5500_config = ETH_W5500_DEFAULT_CONFIG(spi_handle);
+    w5500_config.int_gpio_num = CONFIG_MICRO_ROS_ETH_SPI_INT_GPIO;
+    esp_eth_mac_t *mac = esp_eth_mac_new_w5500(&w5500_config, &mac_config);
+    esp_eth_phy_t *phy = esp_eth_phy_new_w5500(&phy_config);
+#endif
+#endif // CONFIG_ETH_USE_SPI_ETHERNET
+    esp_eth_config_t config = ETH_DEFAULT_CONFIG(mac, phy);
+    esp_eth_handle_t eth_handle = NULL;
+    ESP_ERROR_CHECK(esp_eth_driver_install(&config, &eth_handle));
+#if CONFIG_ETH_USE_SPI_ETHERNET
+    /* The SPI Ethernet module might doesn't have a burned factory MAC address, we cat to set it manually.
+       02:00:00 is a Locally Administered OUI range so should not be used except when testing on a LAN under your control.
+    */
+    ESP_ERROR_CHECK(esp_eth_ioctl(eth_handle, ETH_CMD_S_MAC_ADDR, (uint8_t[]) {
+        0x02, 0x00, 0x00, 0x12, 0x34, 0x56
+    }));
+#endif
+    /* attach Ethernet driver to TCP/IP stack */
+    ESP_ERROR_CHECK(esp_netif_attach(eth_netif, esp_eth_new_netif_glue(eth_handle)));
+    /* start Ethernet driver state machine */
+    ESP_ERROR_CHECK(esp_eth_start(eth_handle));
+
+    return ESP_OK;
+}
+
+#endif

--- a/network_interfaces/uros_network_interfaces.h
+++ b/network_interfaces/uros_network_interfaces.h
@@ -1,0 +1,3 @@
+#include "esp_system.h"
+
+esp_err_t uros_network_interface_initialize(void);

--- a/network_interfaces/uros_wlan_netif.c
+++ b/network_interfaces/uros_wlan_netif.c
@@ -1,0 +1,122 @@
+#include <string.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/event_groups.h"
+#include "esp_system.h"
+#include "esp_wifi.h"
+#include "esp_event.h"
+#include "esp_log.h"
+#include "nvs_flash.h"
+#include "lwip/err.h"
+#include "lwip/sys.h"
+#include "esp_netif.h"
+#include "uros_network_interfaces.h"
+
+#ifdef CONFIG_MICRO_ROS_ESP_NETIF_WLAN
+
+#define ESP_WIFI_SSID      CONFIG_ESP_WIFI_SSID
+#define ESP_WIFI_PASS      CONFIG_ESP_WIFI_PASSWORD
+#define ESP_MAXIMUM_RETRY  CONFIG_ESP_MAXIMUM_RETRY
+#define WIFI_CONNECTED_BIT BIT0
+#define WIFI_FAIL_BIT      BIT1
+
+static EventGroupHandle_t s_wifi_event_group;
+static const char *TAG = "wifi_station_netif";
+static int s_retry_num = 0;
+
+
+static void event_handler(void* arg, esp_event_base_t event_base,
+                                int32_t event_id, void* event_data)
+{
+    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+        esp_wifi_connect();
+    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+        if (s_retry_num < ESP_MAXIMUM_RETRY) {
+            esp_wifi_connect();
+            s_retry_num++;
+            ESP_LOGI(TAG, "retry to connect to the AP");
+        } else {
+            xEventGroupSetBits(s_wifi_event_group, WIFI_FAIL_BIT);
+        }
+        ESP_LOGI(TAG,"connect to the AP fail");
+    } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+        ip_event_got_ip_t* event = (ip_event_got_ip_t*) event_data;
+        ESP_LOGI(TAG, "got ip:" IPSTR, IP2STR(&event->ip_info.ip));
+        s_retry_num = 0;
+        xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
+    }
+}
+
+static void wifi_init_sta(void)
+{
+    s_wifi_event_group = xEventGroupCreate();
+
+    ESP_ERROR_CHECK(esp_netif_init());
+
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+    esp_netif_create_default_wifi_sta();
+
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    ESP_ERROR_CHECK(esp_wifi_init(&cfg));
+
+    ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, ESP_EVENT_ANY_ID, &event_handler, NULL));
+    ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_STA_GOT_IP, &event_handler, NULL));
+
+    wifi_config_t wifi_config = {
+        .sta = {
+            .ssid = ESP_WIFI_SSID,
+            .password = ESP_WIFI_PASS,
+            /* Setting a password implies station will connect to all security modes including WEP/WPA.
+             * However these modes are deprecated and not advisable to be used. Incase your Access point
+             * doesn't support WPA2, these mode can be enabled by commenting below line */
+	     .threshold.authmode = WIFI_AUTH_WPA2_PSK,
+
+            .pmf_cfg = {
+                .capable = true,
+                .required = false
+            },
+        },
+    };
+    ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_STA) );
+    ESP_ERROR_CHECK(esp_wifi_set_config(ESP_IF_WIFI_STA, &wifi_config) );
+    ESP_ERROR_CHECK(esp_wifi_start() );
+
+    ESP_LOGI(TAG, "wifi_init_sta finished.");
+
+    /* Waiting until either the connection is established (WIFI_CONNECTED_BIT) or connection failed for the maximum
+     * number of re-tries (WIFI_FAIL_BIT). The bits are set by event_handler() (see above) */
+    EventBits_t bits = xEventGroupWaitBits(s_wifi_event_group,
+            WIFI_CONNECTED_BIT | WIFI_FAIL_BIT,
+            pdFALSE,
+            pdFALSE,
+            portMAX_DELAY);
+
+    /* xEventGroupWaitBits() returns the bits before the call returned, hence we can test which event actually
+     * happened. */
+    if (bits & WIFI_CONNECTED_BIT) {
+        ESP_LOGI(TAG, "connected to ap SSID:%s password:%s",
+                 ESP_WIFI_SSID, ESP_WIFI_PASS);
+    } else if (bits & WIFI_FAIL_BIT) {
+        ESP_LOGI(TAG, "Failed to connect to SSID:%s, password:%s",
+                 ESP_WIFI_SSID, ESP_WIFI_PASS);
+    } else {
+        ESP_LOGE(TAG, "UNEXPECTED EVENT");
+    }
+}
+
+esp_err_t uros_network_interface_initialize(void)
+{
+    esp_err_t ret = nvs_flash_init();
+    if (ret == ESP_ERR_NVS_NO_FREE_PAGES || ret == ESP_ERR_NVS_NEW_VERSION_FOUND) {
+        ESP_ERROR_CHECK(nvs_flash_erase());
+        ret = nvs_flash_init();
+    }
+    ESP_ERROR_CHECK(ret);
+
+    ESP_LOGI(TAG, "ESP_WIFI_MODE_STA");
+    wifi_init_sta();
+
+    return ret;
+}
+
+#endif


### PR DESCRIPTION
This PR aims to enable support of the Ethernet interface present on ESP32 chips as an alternative to the WIFI.

To avoid breaking the current WIFI transport work, I changed the configuration options of the microROS settings to allow the user to select the proper interface. The default one stills the WIFI.

I also moved the network related to code out of the example and created a separate network_interfaces component, this made the example code a bit less complex to understand by abstracting the details of the selected network interface.

It was tested in the ESP32 Ethernet kit with the default options: https://docs.espressif.com/projects/esp-idf/en/latest/esp32/hw-reference/esp32/get-started-ethernet-kit.html