### PR TITLE
bugfix for ADDITIONAL_CLEAN_FILES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,5 +40,5 @@ add_dependencies(${COMPONENT_LIB} libmicroros-prebuilt)
 target_link_libraries(${COMPONENT_LIB} INTERFACE libmicroros-prebuilt)
 
 set_directory_properties( PROPERTIES ADDITIONAL_CLEAN_FILES
-    "${COMPONENT_LIB}/include;${COMPONENT_LIB}/micro_ros_dev;${COMPONENT_LIB}/micro_ros_src;${COMPONENT_LIB}/esp32_toolchain.cmake" )
+    "${COMPONENT_DIR}/include;${COMPONENT_DIR}/micro_ros_dev;${COMPONENT_DIR}/micro_ros_src;${COMPONENT_DIR}/esp32_toolchain.cmake" )
 


### PR DESCRIPTION
In CMakeLists.txt where the directory property `ADDITIONAL_CLEAN_FILES` is set the variable `COMPONENT_LIB` is used, but it should be `COMPONENT_DIR`.

With these changes the command `idf.py clean` deletes all the build byproducts of micro_ros.