### PR TITLE
optional app-colcon.meta in project directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ else()
 set(submake "make")
 endif()
 
+set(APP_COLCON_META "${PROJECT_DIR}/app-colcon.meta")
+if(NOT EXISTS "${APP_COLCON_META}")
+set(APP_COLCON_META "")
+endif()
+
 externalproject_add(libmicroros_project
     PREFIX     ${CMAKE_BINARY_DIR}/libmicroros-prefix
     SOURCE_DIR ${COMPONENT_DIR}
@@ -24,6 +29,7 @@ externalproject_add(libmicroros_project
             BUILD_DIR=${CMAKE_BINARY_DIR}
             IDF_PATH=${IDF_PATH}
             IDF_TARGET=${IDF_TARGET}
+            APP_COLCON_META=${APP_COLCON_META}
     INSTALL_COMMAND ""
     BUILD_BYPRODUCTS ${COMPONENT_DIR}/libmicroros.a
     )

--- a/examples/int32_publisher_custom_transport/app-colcon.meta
+++ b/examples/int32_publisher_custom_transport/app-colcon.meta
@@ -1,0 +1,9 @@
+{
+    "names": {
+        "rmw_microxrcedds": {
+            "cmake-args": [
+                "-DRMW_UXRCE_TRANSPORT=custom"
+            ]
+        }
+    }
+}

--- a/libmicroros.mk
+++ b/libmicroros.mk
@@ -79,7 +79,7 @@ $(EXTENSIONS_DIR)/micro_ros_src/install: $(EXTENSIONS_DIR)/esp32_toolchain.cmake
 	colcon build \
 		--merge-install \
 		--packages-ignore-regex=.*_cpp \
-		--metas $(EXTENSIONS_DIR)/colcon.meta \
+		--metas $(EXTENSIONS_DIR)/colcon.meta $(APP_COLCON_META) \
 		--cmake-args \
 		"--no-warn-unused-cli" \
 		-DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=OFF \


### PR DESCRIPTION
Makes it possible to have a optional `app-colcon.meta` in the project directory to override project specific options (similar to what is used in [freertos_apps](https://github.com/micro-ROS/freertos_apps/blob/foxy/apps/int32_publisher/app-colcon.meta).

I is quite useful for my use-case where I have this repo as a git-submodule in the components folder. With there changes it's possible to override options in `app-colcon.meta` without having to touch the `colcon.meta` in the git-submodule.

@pablogs9 if you think this is a useful feature I can also update the README before we merge this.