### PR TITLE
Fix for building after sourcing ROS setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This component has been tested in ESP-IDF v4.1, v4.2 and v4.3 with ESP32, ESP32-
 
 ## Dependencies
 
-This componentes needs `colcon` in order to build micro-ROS packages:
+This component needs `colcon` in order to build micro-ROS packages:
 
 <!-- apt install lsb-release git -->
 ```bash
@@ -23,7 +23,9 @@ pip3 install catkin_pkg lark-parser empy
 
 ## Usage
 
-You can clone this repo directly in the `components` folder of your project
+You can clone this repo directly in the `components` folder of your project.
+
+If you encounter issues during the build process, ensure that you are running in a clean shell environment _without_ the ROS 2 setup script sourced.
 
 ## Example
 

--- a/libmicroros.mk
+++ b/libmicroros.mk
@@ -75,6 +75,8 @@ $(EXTENSIONS_DIR)/micro_ros_src/src:
 
 $(EXTENSIONS_DIR)/micro_ros_src/install: $(EXTENSIONS_DIR)/esp32_toolchain.cmake $(EXTENSIONS_DIR)/micro_ros_dev/install $(EXTENSIONS_DIR)/micro_ros_src/src
 	cd $(UROS_DIR); \
+	unset AMENT_PREFIX_PATH; \
+	PATH=$(subst /opt/ros/$(ROS_DISTRO)/bin,,$(PATH)); \
 	. ../micro_ros_dev/install/local_setup.sh; \
 	colcon build \
 		--merge-install \


### PR DESCRIPTION
As detailed in #60, clears the ROS environment from `AMENT_PREFIX_PATH` and `PATH` prior to building the `micro_ros_src` packages.

Also adds a note in the README about trying with a clean environment if there are build issues, as the environment clean-up in the makefile will only fix `PATH` if ROS is installed in `/opt/ros/$(ROS_DISTRO)/bin`.