### PR TITLE
support for vcs import of extra packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,11 @@ if(NOT EXISTS "${APP_COLCON_META}")
 set(APP_COLCON_META "")
 endif()
 
+set(EXTRA_ROS_PACKAGES "${PROJECT_DIR}/extra_ros_packages")
+if(NOT EXISTS "${EXTRA_ROS_PACKAGES}")
+set(EXTRA_ROS_PACKAGES "${COMPONENT_DIR}/extra_packages")
+endif()
+
 externalproject_add(libmicroros_project
     PREFIX     ${CMAKE_BINARY_DIR}/libmicroros-prefix
     SOURCE_DIR ${COMPONENT_DIR}
@@ -32,6 +37,7 @@ externalproject_add(libmicroros_project
             APP_COLCON_META=${APP_COLCON_META}
             IDF_VERSION_MAJOR=${IDF_VERSION_MAJOR}
             IDF_VERSION_MINOR=${IDF_VERSION_MINOR}
+            EXTRA_ROS_PACKAGES=${EXTRA_ROS_PACKAGES}
     INSTALL_COMMAND ""
     BUILD_BYPRODUCTS ${COMPONENT_DIR}/libmicroros.a
     )

--- a/libmicroros.mk
+++ b/libmicroros.mk
@@ -74,7 +74,7 @@ $(EXTENSIONS_DIR)/micro_ros_src/src:
 	touch src/rclc/rclc_examples/COLCON_IGNORE; \
 	touch src/rcl/rcl_yaml_param_parser/COLCON_IGNORE; \
 	cp -rf $(EXTRA_ROS_PACKAGES) src/extra_packages || :; \
-	test -f src/extra_packages/extra_packages.repos && cd src/extra_packages && vcs import --input extra_packages.repos;
+	test -f src/extra_packages/extra_packages.repos && cd src/extra_packages && vcs import --input extra_packages.repos || :;
 
 
 $(EXTENSIONS_DIR)/micro_ros_src/install: $(EXTENSIONS_DIR)/esp32_toolchain.cmake $(EXTENSIONS_DIR)/micro_ros_dev/install $(EXTENSIONS_DIR)/micro_ros_src/src

--- a/libmicroros.mk
+++ b/libmicroros.mk
@@ -73,7 +73,8 @@ $(EXTENSIONS_DIR)/micro_ros_src/src:
 	touch src/rcl_logging/rcl_logging_spdlog/COLCON_IGNORE; \
 	touch src/rclc/rclc_examples/COLCON_IGNORE; \
 	touch src/rcl/rcl_yaml_param_parser/COLCON_IGNORE; \
-	cp -rf ../extra_packages src/extra_packages || :;
+	cp -rf $(EXTRA_ROS_PACKAGES) src/extra_packages || :; \
+	test -f src/extra_packages/extra_packages.repos && cd src/extra_packages && vcs import --input extra_packages.repos;
 
 
 $(EXTENSIONS_DIR)/micro_ros_src/install: $(EXTENSIONS_DIR)/esp32_toolchain.cmake $(EXTENSIONS_DIR)/micro_ros_dev/install $(EXTENSIONS_DIR)/micro_ros_src/src


### PR DESCRIPTION
Implements #31 
If the folder `extra_ros_packages` in the IDF project root exists, it is copied into the micoROS workspace (instead of the `extra_packages` directory in this component).
Also if there is a `extra_packages.repos` file inside the `extra_ros_packages` directory it will be imported with vcs.