### PR TITLE
esp32s3: add esp32s3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Build sample - low_consumption
         shell: bash
-        if: matrix.idf_target != 'esp32c3'
+        if: matrix.idf_target != 'esp32c3' && matrix.idf_target != 'esp32s3'
         run: |
           . $IDF_PATH/export.sh
           cd micro_ros_espidf_component/examples/low_consumption

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_target: [ esp32, esp32s2, esp32c3]
+        idf_target: [ esp32, esp32s2, esp32s3, esp32c3]
         idf_version: [ "espressif/idf:release-v4.1", "espressif/idf:release-v4.2", "espressif/idf:release-v4.3", "espressif/idf:release-v4.4" ]
         exclude:
           - idf_target: esp32s2
@@ -21,6 +21,13 @@ jobs:
             idf_version: "espressif/idf:release-v4.1"
           - idf_target: esp32c3
             idf_version: "espressif/idf:release-v4.2"
+          - idf_target: esp32s3
+            idf_version: "espressif/idf:release-v4.1"
+          - idf_target: esp32s3
+            idf_version: "espressif/idf:release-v4.2"
+          - idf_target: esp32s3
+            idf_version: "espressif/idf:release-v4.3"
+
     container:
       image: ${{ matrix.idf_version }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         branch: [foxy, main, galactic]
-        idf_target: [ esp32, esp32s2, esp32c3]
+        idf_target: [ esp32, esp32s2, esp32c3, esp32s3]
         idf_version: [ "espressif/idf:release-v4.1", "espressif/idf:release-v4.2", "espressif/idf:release-v4.3", "espressif/idf:release-v4.4" ]
         exclude:
           - idf_target: esp32s2
@@ -24,6 +24,12 @@ jobs:
             idf_version: "espressif/idf:release-v4.1"
           - idf_target: esp32c3
             idf_version: "espressif/idf:release-v4.2"
+          - idf_target: esp32s3
+            idf_version: "espressif/idf:release-v4.1"
+          - idf_target: esp32s3
+            idf_version: "espressif/idf:release-v4.2"
+          - idf_target: esp32s3
+            idf_version: "espressif/idf:release-v4.3"
     container:
       image: ${{ matrix.idf_version }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,6 +60,7 @@ jobs:
 
       - name: Build sample - low_consumption
         shell: bash
+        if: matrix.idf_target != 'esp32c3' && matrix.idf_target != 'esp32s3'
         run: |
           . $IDF_PATH/export.sh
           cd micro_ros_espidf_component/examples/low_consumption

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ In order to test a int32_publisher example:
 ```bash
 . $IDF_PATH/export.sh
 cd examples/int32_publisher
-# Set target board [esp32|esp32s2|esp32s3|esp32c3|]
+# Set target board [esp32|esp32s2|esp32s3|esp32c3]
 idf.py set-target esp32
 idf.py menuconfig
 # Set your micro-ROS configuration and WiFi credentials under micro-ROS Settings

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # micro-ROS component for ESP-IDF
 
-This component has been tested in ESP-IDF v4.1, v4.2, v4.3 and v4.4 with ESP32, ESP32-S2 and ESP32-C3.
+This component has been tested in ESP-IDF v4.1, v4.2, v4.3 and v4.4 with ESP32, ESP32-S2, ESP32-S3 and ESP32-C3.
 
 ## Dependencies
 
@@ -31,7 +31,7 @@ In order to test a int32_publisher example:
 ```bash
 . $IDF_PATH/export.sh
 cd examples/int32_publisher
-# Set target board [esp32|esp32s2|esp32c3]
+# Set target board [esp32|esp32s2|esp32s3|esp32c3|]
 idf.py set-target esp32
 idf.py menuconfig
 # Set your micro-ROS configuration and WiFi credentials under micro-ROS Settings


### PR DESCRIPTION
This PR adds support for esp32s3 SoC, no major changes required, the IDF 4.4 does most of the job, I just added it to the CI and updated the documentation.

Any esp32s3 development kit should work fine. 