### PR TITLE
make micro ros epsidf work with IDF 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
           pip3 install catkin_pkg lark-parser empy colcon-common-extensions
           # This line avoids the error when using Python < 3.7 https://importlib-resources.readthedocs.io/en/latest/
           pip3 install importlib-resources
+          # this installs the modules also for global python interpreter, needed for IDF v5
+          /usr/bin/pip3 install catkin_pkg lark-parser empy colcon-common-extensions importlib-resources
 
       - name: Build sample - int32_publisher
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         idf_target: [ esp32, esp32s2, esp32s3, esp32c3]
-        idf_version: [ "espressif/idf:release-v4.1", "espressif/idf:release-v4.2", "espressif/idf:release-v4.3", "espressif/idf:release-v4.4" ]
+        idf_version: [ "espressif/idf:release-v4.1", "espressif/idf:release-v4.2", "espressif/idf:release-v4.3", "espressif/idf:release-v4.4", "espressif/idf:release-v5.0" ]
         exclude:
           - idf_target: esp32s2
             idf_version: "espressif/idf:release-v4.1"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,6 +49,8 @@ jobs:
           pip3 install catkin_pkg lark-parser empy colcon-common-extensions
           # This line avoids the error when using Python < 3.7 https://importlib-resources.readthedocs.io/en/latest/
           pip3 install importlib-resources
+          # this installs the modules also for global python interpreter, needed for IDF v5
+          /usr/bin/pip3 install catkin_pkg lark-parser empy colcon-common-extensions importlib-resources
 
       - name: Build sample - int32_publisher
         shell: bash

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         branch: [foxy, main, galactic, humble]
         idf_target: [ esp32, esp32s2, esp32c3, esp32s3]
-        idf_version: [ "espressif/idf:release-v4.1", "espressif/idf:release-v4.2", "espressif/idf:release-v4.3", "espressif/idf:release-v4.4" ]
+        idf_version: [ "espressif/idf:release-v4.1", "espressif/idf:release-v4.2", "espressif/idf:release-v4.3", "espressif/idf:release-v4.4", "espressif/idf:release-v5.0" ]
         exclude:
           - idf_target: esp32s2
             idf_version: "espressif/idf:release-v4.1"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(SRCS "network_interfaces/uros_ethernet_netif.c" "network_interfaces/uros_wlan_netif.c"
                        INCLUDE_DIRS "network_interfaces"
-                       REQUIRES nvs_flash)
+                       REQUIRES nvs_flash esp_wifi esp_eth)
 
 if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
 set(submake "$(MAKE)")

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # micro-ROS component for ESP-IDF
 
-This component has been tested in ESP-IDF v4.1, v4.2, v4.3 and v4.4 with ESP32, ESP32-S2, ESP32-S3 and ESP32-C3.
+This component has been tested in ESP-IDF v4.1, v4.2, v4.3, v4.4, and v5.0 with ESP32, ESP32-S2, ESP32-S3 and ESP32-C3.
 
 ## Dependencies
 
@@ -64,7 +64,7 @@ It's possible to build this example application using preconfigured docker conta
 docker run -it --rm --user espidf --volume="/etc/timezone:/etc/timezone:ro" -v  $(pwd):/micro_ros_espidf_component -v  /dev:/dev --privileged --workdir /micro_ros_espidf_component microros/esp-idf-microros:latest /bin/bash  -c "cd examples/int32_publisher; idf.py menuconfig build flash monitor"
 ```
 
-Dockerfile for this container is provided in the ./docker directory and available in dockerhub.
+Dockerfile for this container is provided in the ./docker directory and available in dockerhub. For ESP-IDF v5 use the Dockerfile5 file.
 
 ## Using serial transport
 

--- a/docker/Dockerfilev5
+++ b/docker/Dockerfilev5
@@ -1,0 +1,30 @@
+
+
+FROM espressif/idf:release-v5.0
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN echo "Set disable_coredump false" >> /etc/sudo.conf
+RUN apt update -q && \
+    apt install -yq sudo lsb-release gosu nano && \
+    rm -rf /var/lib/apt/lists/*
+
+ARG TZ_ARG=UTC
+ENV TZ=$TZ_ARG
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+
+COPY ./install_micro_ros_deps_script.sh /install_micro_ros_deps_script.sh
+
+RUN mkdir -p /tmp/install_micro_ros_deps_script && mv /install_micro_ros_deps_script.sh /tmp/install_micro_ros_deps_script/ && \
+    IDF_EXPORT_QUIET=1 /tmp/install_micro_ros_deps_script/install_micro_ros_deps_script.sh && \
+    rm -rf /var/lib/apt/lists/*
+	
+RUN /usr/bin/pip3 --no-cache-dir install catkin_pkg lark-parser empy colcon-common-extensions importlib-resources
+ARG USER_ID=espidf
+
+RUN useradd --create-home --home-dir /home/$USER_ID --shell /bin/bash --user-group --groups adm,sudo $USER_ID && \
+    echo $USER_ID:$USER_ID | chpasswd && \
+    echo "$USER_ID ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+ARG USER_ID
+USER $USER_ID

--- a/esp32_toolchain.cmake.in
+++ b/esp32_toolchain.cmake.in
@@ -33,11 +33,16 @@ include_directories(
         ${idf_path}/components/freertos/include
         ${idf_path}/components/freertos/${CMAKE_SYSTEM_PROCESSOR}/include
         ${idf_path}/components/freertos/port/${CMAKE_SYSTEM_PROCESSOR}/include
+	${idf_path}/components/freertos/FreeRTOS-Kernel/portable/${CMAKE_SYSTEM_PROCESSOR}/include
+	${idf_path}/components/freertos/FreeRTOS-Kernel/include
+	${idf_path}/components/freertos/esp_additions/include
+	${idf_path}/components/freertos/esp_additions/include/freertos
         ${idf_path}/components/esp_hw_support/include
         ${idf_path}/components/hal/include
         ${idf_path}/components/hal/${idf_target}/include
         ${idf_path}/components/heap/include
         ${idf_path}/components/log/include
+        ${idf_path}/components/lwip/include
         ${idf_path}/components/lwip/include/apps
         ${idf_path}/components/lwip/include/apps/sntp
         ${idf_path}/components/lwip/lwip/src/include

--- a/examples/int32_publisher/main/main.c
+++ b/examples/int32_publisher/main/main.c
@@ -28,7 +28,11 @@ void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
 {
 	RCLC_UNUSED(last_call_time);
 	if (timer != NULL) {
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
 		printf("Publishing: %ld\n", msg.data);
+#else
+		printf("Publishing: %d\n", msg.data);
+#endif
 		RCSOFTCHECK(rcl_publish(&publisher, &msg, NULL));
 		msg.data++;
 	}

--- a/examples/int32_publisher/main/main.c
+++ b/examples/int32_publisher/main/main.c
@@ -28,7 +28,7 @@ void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
 {
 	RCLC_UNUSED(last_call_time);
 	if (timer != NULL) {
-		printf("Publishing: %d\n", msg.data);
+		printf("Publishing: %ld\n", msg.data);
 		RCSOFTCHECK(rcl_publish(&publisher, &msg, NULL));
 		msg.data++;
 	}

--- a/examples/int32_publisher_custom_transport/main/esp32_serial_transport.c
+++ b/examples/int32_publisher_custom_transport/main/esp32_serial_transport.c
@@ -49,6 +49,6 @@ size_t esp32_serial_write(struct uxrCustomTransport* transport, const uint8_t * 
 
 size_t esp32_serial_read(struct uxrCustomTransport* transport, uint8_t* buf, size_t len, int timeout, uint8_t* err){
     size_t * uart_port = (size_t*) transport->args;
-    const int rxBytes = uart_read_bytes(*uart_port, buf, len, timeout / portTICK_RATE_MS);
+    const int rxBytes = uart_read_bytes(*uart_port, buf, len, timeout / portTICK_PERIOD_MS);
     return rxBytes;
 }

--- a/examples/int32_publisher_embeddedrtps/main/main.c
+++ b/examples/int32_publisher_embeddedrtps/main/main.c
@@ -24,7 +24,11 @@ void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
 {
 	RCLC_UNUSED(last_call_time);
 	if (timer != NULL) {
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+		printf("Publishing: %ld\n", msg.data);
+#else
 		printf("Publishing: %d\n", msg.data);
+#endif
 		RCSOFTCHECK(rcl_publish(&publisher, &msg, NULL));
 		msg.data++;
 	}

--- a/examples/int32_sub_pub/main/main.c
+++ b/examples/int32_sub_pub/main/main.c
@@ -31,7 +31,11 @@ void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
 	(void) last_call_time;
 	if (timer != NULL) {
 		RCSOFTCHECK(rcl_publish(&publisher, &send_msg, NULL));
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+		printf("Sent: %ld\n", send_msg.data);
+#else
 		printf("Sent: %d\n", send_msg.data);
+#endif
 		send_msg.data++;
 	}
 }
@@ -39,7 +43,11 @@ void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
 void subscription_callback(const void * msgin)
 {
 	const std_msgs__msg__Int32 * msg = (const std_msgs__msg__Int32 *)msgin;
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 0, 0)
+	printf("Received: %ld\n", msg->data);
+#else
 	printf("Received: %d\n", msg->data);
+#endif
 }
 
 void micro_ros_task(void * arg)

--- a/libmicroros.mk
+++ b/libmicroros.mk
@@ -118,6 +118,11 @@ ifeq ($(IDF_TARGET),$(filter $(IDF_TARGET),esp32s2 esp32c3))
 			$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_load_8; \
 			$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_store_8; \
 		fi; \
+		if [ $(IDF_VERSION_MAJOR) -ge 5 ] && [ $(IDF_VERSION_MINOR) -ge 0 ]; then \
+			$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_load_8; \
+			$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_store_8; \
+			$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_exchange_8; \
+		fi; \
 		$(X_AR) rc -s librcutils.a *.obj; \
 		cp -rf librcutils.a  $(UROS_DIR)/install/lib/librcutils.a; \
 		rm -rf $(UROS_DIR)/atomic_workaround; \


### PR DESCRIPTION
This pull request enables building micro ros with ESP IDE 5

To test is, a new Dockerfile referencing to IDF 5 is also included.

Changes:
* Adding a few includes
* fixing a bad format in int32_publisher (may also be needed with the other examples, but i was only testing with this one)
* Pull request "Update CMakeLists.txt # 160" ist also included.

Tested with EPS32S3 with included docker container and also with platform.io ESP IDF 5.1.1 platform