### PR TITLE
Update to new RCL fork

### DIFF
--- a/colcon.meta
+++ b/colcon.meta
@@ -8,8 +8,7 @@
         },
         "rcl":{
             "cmake-args":[
-                "-DRCL_COMMAND_LINE_ENABLED=OFF",
-                "-DRCL_LOGGING_ENABLED=OFF"
+                "-DRCL_MICROROS=ON"
             ]
         },
         "rcutils": {

--- a/libmicroros.mk
+++ b/libmicroros.mk
@@ -55,7 +55,7 @@ $(EXTENSIONS_DIR)/micro_ros_src/src:
 		git clone -b ros2 https://github.com/eProsima/Micro-XRCE-DDS-Client src/Micro-XRCE-DDS-Client; \
 		git clone -b main https://github.com/micro-ROS/rmw_microxrcedds src/rmw_microxrcedds; \
 	fi; \
-	git clone -b foxy https://github.com/eProsima/micro-CDR src/micro-CDR; \
+	git clone -b ros2 https://github.com/eProsima/micro-CDR src/micro-CDR; \
 	git clone -b master https://github.com/micro-ROS/rcl src/rcl; \
 	git clone -b master https://github.com/ros2/rclc src/rclc; \
 	git clone -b master https://github.com/micro-ROS/rcutils src/rcutils; \
@@ -72,7 +72,7 @@ $(EXTENSIONS_DIR)/micro_ros_src/src:
 	git clone -b master https://github.com/ros2/test_interface_files src/test_interface_files; \
 	git clone -b master https://github.com/ros2/rmw_implementation src/rmw_implementation; \
 	git clone -b master https://github.com/ros2/rcl_logging src/rcl_logging; \
-	git clone -b master https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing src/ros2_tracing; \
+	git clone -b master https://github.com/ros2/ros2_tracing src/ros2_tracing; \
 	git clone -b main https://github.com/micro-ROS/micro_ros_utilities src/micro_ros_utilities; \
 	git clone -b rolling https://github.com/ros2/rosidl_core src/rosidl_core; \
     touch src/rosidl/rosidl_typesupport_introspection_cpp/COLCON_IGNORE; \


### PR DESCRIPTION
This PR uses a new approach at RCL micro-ROS fork for `rolling`: https://github.com/micro-ROS/rcl/commit/5c2e2f25da38cce442a1decbb065ffc15a4fa2ee

This changes shall be applied to all micro-ROS components