### PR TITLE
Pin empy version to 3.3.4 inside Dockerfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This component needs `colcon` and other Python 3 packages inside the IDF virtual
 
 ```bash
 . $IDF_PATH/export.sh
-pip3 install catkin_pkg lark-parser colcon-common-extensions
+pip3 install catkin_pkg lark-parser colcon-common-extensions empy==3.3.4
 ```
 
 ## Middlewares available

--- a/docker/install_micro_ros_deps_script.sh
+++ b/docker/install_micro_ros_deps_script.sh
@@ -5,6 +5,6 @@ set -eu
 sudo apt update -q
 sudo apt install -yq python3-pip
 source $IDF_PATH/export.sh
-pip3 install catkin_pkg lark-parser colcon-common-extensions importlib-resources
+pip3 install catkin_pkg lark-parser colcon-common-extensions importlib-resources empy==3.3.4
 
 set +u


### PR DESCRIPTION
This pull request **pins empy inside the Dockerfile** which comes with this repository **to version 3.3.4** in order to avoid the compilation problem discussed in #268.