### PR TITLE
Initial support for the ESP32 C6 board

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
       matrix:
         idf_target: [ esp32, esp32s2, esp32s3, esp32c3, esp32c6]
         idf_version: [ "espressif/idf:release-v4.4", "espressif/idf:release-v5.2" ]
+        exclude:
+          # Skip IDF v4 + ESP32C6 combination
+          - idf_target: esp32c6
+            idf_version: espressif/idf:release-v4.4
 
     container:
       image: ${{ matrix.idf_version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_target: [ esp32, esp32s2, esp32s3, esp32c3]
+        idf_target: [ esp32, esp32s2, esp32s3, esp32c3, esp32c6]
         idf_version: [ "espressif/idf:release-v4.4", "espressif/idf:release-v5.2" ]
 
     container:
@@ -54,7 +54,7 @@ jobs:
 
       - name: Build sample - low_consumption
         shell: bash
-        if: matrix.idf_target != 'esp32c3' && matrix.idf_target != 'esp32s3'
+        if: matrix.idf_target != 'esp32c3' && matrix.idf_target != 'esp32s3' && matrix.idf_target != 'esp32c6'
         run: |
           . $IDF_PATH/export.sh
           cd micro_ros_espidf_component/examples/low_consumption

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         branch: [iron, rolling, jazzy, humble]
-        idf_target: [ esp32, esp32s2, esp32c3, esp32s3]
+        idf_target: [ esp32, esp32s2, esp32c3, esp32s3, esp32c6]
         idf_version: [ "espressif/idf:release-v4.4", "espressif/idf:release-v5.2" ]
 
     container:
@@ -58,7 +58,7 @@ jobs:
 
       - name: Build sample - low_consumption
         shell: bash
-        if: matrix.idf_target != 'esp32c3' && matrix.idf_target != 'esp32s3'
+        if: matrix.idf_target != 'esp32c3' && matrix.idf_target != 'esp32s3' && matrix.idf_target != 'esp32c6'
         run: |
           . $IDF_PATH/export.sh
           cd micro_ros_espidf_component/examples/low_consumption

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,6 +17,11 @@ jobs:
         branch: [iron, rolling, jazzy, humble]
         idf_target: [ esp32, esp32s2, esp32c3, esp32s3, esp32c6]
         idf_version: [ "espressif/idf:release-v4.4", "espressif/idf:release-v5.2" ]
+        exclude:
+          # Skip IDF v4 + ESP32C6 combination
+          - idf_target: esp32c6
+            idf_version: espressif/idf:release-v4.4
+
 
     container:
       image: ${{ matrix.idf_version }}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # micro-ROS component for ESP-IDF
 
-This component has been tested in ESP-IDF v4.4, and v5.2 with ESP32, ESP32-S2, ESP32-S3 and ESP32-C3.
+This component has been tested in ESP-IDF v4.4, and v5.2 with ESP32, ESP32-S2, ESP32-S3, ESP32-C3 and ESP32-C6.
 
 ## Dependencies
 

--- a/esp32_toolchain.cmake.in
+++ b/esp32_toolchain.cmake.in
@@ -5,7 +5,9 @@ set(CMAKE_SYSTEM_NAME Generic)
 set(idf_target "@IDF_TARGET@")
 set(idf_path "@IDF_PATH@")
 
-if("${idf_target}" STREQUAL "esp32c3")
+set(RISCV_TARGETS "esp32c3" "esp32c6")
+
+if("${idf_target}" IN_LIST RISCV_TARGETS)
     set(CMAKE_SYSTEM_PROCESSOR riscv)
     set(FLAGS "-ffunction-sections -fdata-sections" CACHE STRING "" FORCE)
 else()

--- a/libmicroros.mk
+++ b/libmicroros.mk
@@ -111,7 +111,7 @@ $(EXTENSIONS_DIR)/micro_ros_src/install: $(EXTENSIONS_DIR)/esp32_toolchain.cmake
 
 patch_atomic:$(EXTENSIONS_DIR)/micro_ros_src/install
 # Workaround https://github.com/micro-ROS/micro_ros_espidf_component/issues/18
-ifeq ($(IDF_TARGET),$(filter $(IDF_TARGET),esp32s2 esp32c3))
+ifeq ($(IDF_TARGET),$(filter $(IDF_TARGET),esp32s2 esp32c3 esp32c6))
 		echo $(UROS_DIR)/atomic_workaround; \
 		mkdir $(UROS_DIR)/atomic_workaround; cd $(UROS_DIR)/atomic_workaround; \
 		$(X_AR) x $(UROS_DIR)/install/lib/librcutils.a; \


### PR DESCRIPTION
This make it possible to set board target and build for the RISC-V board on the ESP32 C6 Board.

The C6 is not added to the CI workflow in this PR.  