### PR TITLE
Update deprecated timer function to rclc_timer_init_default2

### DIFF
--- a/examples/handle_static_types/main/main.c
+++ b/examples/handle_static_types/main/main.c
@@ -73,11 +73,12 @@ void micro_ros_task(void * arg)
 	// create timer,
 	rcl_timer_t timer;
 	const unsigned int timer_timeout = 1000;
-	RCCHECK(rclc_timer_init_default(
+	RCCHECK(rclc_timer_init_default2(
 		&timer,
 		&support,
 		RCL_MS_TO_NS(timer_timeout),
-		timer_callback));
+		timer_callback,
+		true));
 
 	// create executor
 	rclc_executor_t executor;

--- a/examples/int32_publisher/main/main.c
+++ b/examples/int32_publisher/main/main.c
@@ -67,11 +67,12 @@ void micro_ros_task(void * arg)
 	// create timer,
 	rcl_timer_t timer;
 	const unsigned int timer_timeout = 1000;
-	RCCHECK(rclc_timer_init_default(
+	RCCHECK(rclc_timer_init_default2(
 		&timer,
 		&support,
 		RCL_MS_TO_NS(timer_timeout),
-		timer_callback));
+		timer_callback,
+		true));
 
 	// create executor
 	rclc_executor_t executor;

--- a/examples/int32_publisher_custom_transport/main/main.c
+++ b/examples/int32_publisher_custom_transport/main/main.c
@@ -55,11 +55,12 @@ void micro_ros_task(void * arg)
 	// create timer,
 	rcl_timer_t timer;
 	const unsigned int timer_timeout = 1000;
-	RCCHECK(rclc_timer_init_default(
+	RCCHECK(rclc_timer_init_default2(
 		&timer,
 		&support,
 		RCL_MS_TO_NS(timer_timeout),
-		timer_callback));
+		timer_callback,
+		true));
 
 	// create executor
 	rclc_executor_t executor;

--- a/examples/int32_publisher_embeddedrtps/main/main.c
+++ b/examples/int32_publisher_embeddedrtps/main/main.c
@@ -55,11 +55,12 @@ void micro_ros_task(void * arg)
 	// create timer,
 	rcl_timer_t timer;
 	const unsigned int timer_timeout = 1000;
-	RCCHECK(rclc_timer_init_default(
+	RCCHECK(rclc_timer_init_default2(
 		&timer,
 		&support,
 		RCL_MS_TO_NS(timer_timeout),
-		timer_callback));
+		timer_callback,
+		true));
 
 	// create executor
 	rclc_executor_t executor;

--- a/examples/int32_sub_pub/main/main.c
+++ b/examples/int32_sub_pub/main/main.c
@@ -82,11 +82,12 @@ void micro_ros_task(void * arg)
 	// Create timer.
 	rcl_timer_t timer = rcl_get_zero_initialized_timer();
 	const unsigned int timer_timeout = 1000;
-	RCCHECK(rclc_timer_init_default(
+	RCCHECK(rclc_timer_init_default2(
 		&timer,
 		&support,
 		RCL_MS_TO_NS(timer_timeout),
-		timer_callback));
+		timer_callback,
+		true));
 
 	// Create executor.
 	rclc_executor_t executor = rclc_executor_get_zero_initialized_executor();

--- a/examples/low_consumption/main/main.c
+++ b/examples/low_consumption/main/main.c
@@ -83,11 +83,12 @@ void micro_ros_task(void * arg)
 	// create timer,
 	rcl_timer_t timer;
 	const unsigned int timer_timeout = 1000;
-	RCCHECK(rclc_timer_init_default(
+	RCCHECK(rclc_timer_init_default2(
 		&timer,
 		&support,
 		RCL_MS_TO_NS(timer_timeout),
-		timer_callback));
+		timer_callback,
+		true));
 
 	// create executor
 	rclc_executor_t executor;

--- a/examples/parameters/main/main.c
+++ b/examples/parameters/main/main.c
@@ -79,11 +79,12 @@ void micro_ros_task(void * arg)
 
     // create timer,
     rcl_timer_t timer;
-    rclc_timer_init_default(
+    RCCHECK(rclc_timer_init_default2(
         &timer,
         &support,
         RCL_MS_TO_NS(1000),
-        timer_callback);
+        timer_callback,
+        true));
 
     // Create executor
     rclc_executor_t executor;

--- a/examples/ping_pong/main/main.c
+++ b/examples/ping_pong/main/main.c
@@ -133,7 +133,8 @@ void micro_ros_task(void * arg)
 
 	// Create a 3 seconds ping timer timer,
 	rcl_timer_t timer;
-	RCCHECK(rclc_timer_init_default(&timer, &support, RCL_MS_TO_NS(2000), ping_timer_callback));
+	RCCHECK(rclc_timer_init_default2(&timer, &support, RCL_MS_TO_NS(2000),
+		ping_timer_callback, true));
 
 
 	// Create executor

--- a/examples/ping_pong/main/main.c
+++ b/examples/ping_pong/main/main.c
@@ -131,7 +131,7 @@ void micro_ros_task(void * arg)
 		ROSIDL_GET_MSG_TYPE_SUPPORT(std_msgs, msg, Header), "/microROS/pong"));
 
 
-	// Create a 3 seconds ping timer timer,
+	// Create a 2 seconds ping timer timer,
 	rcl_timer_t timer;
 	RCCHECK(rclc_timer_init_default2(&timer, &support, RCL_MS_TO_NS(2000),
 		ping_timer_callback, true));


### PR DESCRIPTION
Remove the use of deprecated function _rclc_timer_init_default_ in favor of _rclc_timer_init_default2_
https://docs.ros.org/en/ros2_packages/rolling/api/rclc/generated/function_timer_8h_1a5ec488ae787fd26afb8656b798abf3e1.html

