### PR TITLE
Add ESP32-P4 support for micro-ROS to use with ROS2 Jazzy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        idf_target: [ esp32, esp32s2, esp32s3, esp32c3, esp32c6]
-        idf_version: [ "espressif/idf:release-v4.4", "espressif/idf:release-v5.2" ]
+        idf_target: [ esp32, esp32s2, esp32s3, esp32c3, esp32c6, esp32p4]
+        idf_version: [ "espressif/idf:release-v4.4", "espressif/idf:release-v5.2", "espressif/idf:release-v5.5" ]
         exclude:
           # Skip IDF v4 + ESP32C6 combination
           - idf_target: esp32c6
             idf_version: espressif/idf:release-v4.4
+          # Skip IDF v4 + ESP32-P4 combination
+          - idf_target: esp32p4
+            idf_version: espressif/idf:release-v4.4
+          # Skip IDF v5.2 + ESP32-P4 combination
+          - idf_target: esp32p4
+            idf_version: espressif/idf:release-v5.2
 
     container:
       image: ${{ matrix.idf_version }}
@@ -38,7 +44,12 @@ jobs:
           # This line avoids the error when using Python < 3.7 https://importlib-resources.readthedocs.io/en/latest/
           pip3 install importlib-resources
           # this installs the modules also for global python interpreter, needed for IDF v5
-          /usr/bin/pip3 install catkin_pkg lark-parser colcon-common-extensions empy==3.3.4 importlib-resources
+          # IDF 5.5 uses Python 3.12 which has externally-managed-environment protection
+          if [ "${{ matrix.idf_version }}" == "espressif/idf:release-v5.5" ]; then \
+            /usr/bin/pip3 install --break-system-packages catkin_pkg lark-parser colcon-common-extensions empy==3.3.4 importlib-resources; \
+          else \
+            /usr/bin/pip3 install catkin_pkg lark-parser colcon-common-extensions empy==3.3.4 importlib-resources; \
+          fi
 
       # This line can be removed when https://github.com/colcon/colcon-python-setup-py/issues/56 is solved
       - name: Patch setuptools
@@ -58,7 +69,7 @@ jobs:
 
       - name: Build sample - low_consumption
         shell: bash
-        if: matrix.idf_target != 'esp32c3' && matrix.idf_target != 'esp32s3' && matrix.idf_target != 'esp32c6'
+        if: matrix.idf_target != 'esp32c3' && matrix.idf_target != 'esp32s3' && matrix.idf_target != 'esp32c6' && matrix.idf_target != 'esp32p4'
         run: |
           . $IDF_PATH/export.sh
           cd micro_ros_espidf_component/examples/low_consumption

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,12 +15,18 @@ jobs:
       fail-fast: false
       matrix:
         branch: [rolling, jazzy, humble]
-        idf_target: [ esp32, esp32s2, esp32c3, esp32s3, esp32c6]
-        idf_version: [ "espressif/idf:release-v4.4", "espressif/idf:release-v5.2" ]
+        idf_target: [ esp32, esp32s2, esp32c3, esp32s3, esp32c6, esp32p4]
+        idf_version: [ "espressif/idf:release-v4.4", "espressif/idf:release-v5.2", "espressif/idf:release-v5.5" ]
         exclude:
           # Skip IDF v4 + ESP32C6 combination
           - idf_target: esp32c6
             idf_version: espressif/idf:release-v4.4
+          # Skip IDF v4 + ESP32-P4 combination
+          - idf_target: esp32p4
+            idf_version: espressif/idf:release-v4.4
+          # Skip IDF v5.2 + ESP32-P4 combination
+          - idf_target: esp32p4
+            idf_version: espressif/idf:release-v5.2
 
 
     container:
@@ -43,7 +49,12 @@ jobs:
           # This line avoids the error when using Python < 3.7 https://importlib-resources.readthedocs.io/en/latest/
           pip3 install importlib-resources
           # this installs the modules also for global python interpreter, needed for IDF v5
-          /usr/bin/pip3 install catkin_pkg lark-parser empy==3.3.4 colcon-common-extensions importlib-resources
+          # IDF 5.5 uses Python 3.12 which has externally-managed-environment protection
+          if [ "${{ matrix.idf_version }}" == "espressif/idf:release-v5.5" ]; then \
+            /usr/bin/pip3 install --break-system-packages catkin_pkg lark-parser colcon-common-extensions importlib-resources; \
+          else \
+            /usr/bin/pip3 install catkin_pkg lark-parser colcon-common-extensions importlib-resources; \
+          fi
 
       # This line can be removed when https://github.com/colcon/colcon-python-setup-py/issues/56 is solved
       - name: Patch setuptools
@@ -63,7 +74,7 @@ jobs:
 
       - name: Build sample - low_consumption
         shell: bash
-        if: matrix.idf_target != 'esp32c3' && matrix.idf_target != 'esp32s3' && matrix.idf_target != 'esp32c6'
+        if: matrix.idf_target != 'esp32c3' && matrix.idf_target != 'esp32s3' && matrix.idf_target != 'esp32c6' && matrix.idf_target != 'esp32p4'
         run: |
           . $IDF_PATH/export.sh
           cd micro_ros_espidf_component/examples/low_consumption

--- a/Kconfig.projbuild
+++ b/Kconfig.projbuild
@@ -71,13 +71,13 @@ menu "Ethernet Configuration"
 
     choice MICRO_ROS_ETHERNET_TYPE
         prompt "Ethernet Type"
-        default MICRO_ROS_USE_INTERNAL_ETHERNET if IDF_TARGET_ESP32
+        default MICRO_ROS_USE_INTERNAL_ETHERNET if IDF_TARGET_ESP32 || IDF_TARGET_ESP32P4
         default MICRO_ROS_USE_W5500
         help
             Select which kind of Ethernet will be used in the example.
 
         config MICRO_ROS_USE_INTERNAL_ETHERNET
-            depends on IDF_TARGET_ESP32
+            depends on IDF_TARGET_ESP32 || IDF_TARGET_ESP32P4
             select ETH_USE_ESP32_EMAC
             bool "Internal EMAC"
             help
@@ -140,12 +140,14 @@ menu "Ethernet Configuration"
 
         config MICRO_ROS_ETH_MDC_GPIO
             int "SMI MDC GPIO number"
+            default 31 if IDF_TARGET_ESP32P4
             default 23
             help
                 Set the GPIO number used by SMI MDC.
 
         config MICRO_ROS_ETH_MDIO_GPIO
             int "SMI MDIO GPIO number"
+            default 52 if IDF_TARGET_ESP32P4
             default 18
             help
                 Set the GPIO number used by SMI MDIO.
@@ -203,6 +205,7 @@ menu "Ethernet Configuration"
 
     config MICRO_ROS_ETH_PHY_RST_GPIO
         int "PHY Reset GPIO number"
+        default 51 if IDF_TARGET_ESP32P4
         default 5
         help
             Set the GPIO number used to reset PHY chip.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # micro-ROS component for ESP-IDF
 
-This component has been tested in ESP-IDF v4.4, and v5.2 with ESP32, ESP32-S2, ESP32-S3, ESP32-C3 and ESP32-C6.
+This component has been tested in ESP-IDF v4.4, v5.2, and v5.5 with ESP32, ESP32-S2, ESP32-S3, ESP32-C3, ESP32-C6 and ESP32-P4.
 
 ## Dependencies
 
@@ -34,7 +34,7 @@ In order to test a int32_publisher example:
 ```bash
 . $IDF_PATH/export.sh
 cd examples/int32_publisher
-# Set target board [esp32|esp32s2|esp32s3|esp32c3]
+# Set target board [esp32|esp32s2|esp32s3|esp32c3|esp32c6|esp32p4]
 idf.py set-target esp32
 idf.py menuconfig
 # Set your micro-ROS configuration and WiFi credentials under micro-ROS Settings

--- a/esp32_toolchain.cmake.in
+++ b/esp32_toolchain.cmake.in
@@ -5,11 +5,18 @@ set(CMAKE_SYSTEM_NAME Generic)
 set(idf_target "@IDF_TARGET@")
 set(idf_path "@IDF_PATH@")
 
-set(RISCV_TARGETS "esp32c3" "esp32c6")
+set(RISCV_TARGETS "esp32c3" "esp32c6" "esp32p4")
+set(RISCV_HARD_FLOAT_TARGETS "esp32p4")
 
 if("${idf_target}" IN_LIST RISCV_TARGETS)
     set(CMAKE_SYSTEM_PROCESSOR riscv)
-    set(FLAGS "-ffunction-sections -fdata-sections" CACHE STRING "" FORCE)
+    if("${idf_target}" IN_LIST RISCV_HARD_FLOAT_TARGETS)
+        # ESP32-P4 uses hardware floating point
+        set(FLAGS "-march=rv32imafc -mabi=ilp32f -ffunction-sections -fdata-sections" CACHE STRING "" FORCE)
+    else()
+        # ESP32-C3/C6 use soft-float
+        set(FLAGS "-ffunction-sections -fdata-sections" CACHE STRING "" FORCE)
+    endif()
 else()
     set(CMAKE_SYSTEM_PROCESSOR xtensa)
     set(FLAGS "-mlongcalls -ffunction-sections -fdata-sections" CACHE STRING "" FORCE)
@@ -35,3 +42,9 @@ include_directories(
         "@BUILD_CONFIG_DIR@"
         ${idf_path}/components/soc/${idf_target}/include
     )
+
+if("${idf_target}" IN_LIST RISCV_TARGETS)
+    include_directories(
+        ${idf_path}/components/riscv/include
+    )
+endif()

--- a/examples/addtwoints_server/.gitignore
+++ b/examples/addtwoints_server/.gitignore
@@ -1,3 +1,5 @@
 build
+managed_components
+dependencies.lock
 sdkconfig
 sdkconfig.old

--- a/examples/handle_static_types/.gitignore
+++ b/examples/handle_static_types/.gitignore
@@ -1,3 +1,5 @@
 build
+managed_components
+dependencies.lock
 sdkconfig
 sdkconfig.old

--- a/examples/int32_publisher/.gitignore
+++ b/examples/int32_publisher/.gitignore
@@ -1,3 +1,5 @@
 build
+managed_components
+dependencies.lock
 sdkconfig
 sdkconfig.old

--- a/examples/int32_publisher_custom_transport/.gitignore
+++ b/examples/int32_publisher_custom_transport/.gitignore
@@ -1,3 +1,5 @@
 build
+managed_components
+dependencies.lock
 sdkconfig
 sdkconfig.old

--- a/examples/int32_publisher_embeddedrtps/.gitignore
+++ b/examples/int32_publisher_embeddedrtps/.gitignore
@@ -1,3 +1,5 @@
 build
+managed_components
+dependencies.lock
 sdkconfig
 sdkconfig.old

--- a/examples/int32_sub_pub/.gitignore
+++ b/examples/int32_sub_pub/.gitignore
@@ -1,3 +1,5 @@
 build
+managed_components
+dependencies.lock
 sdkconfig
 sdkconfig.old

--- a/examples/low_consumption/.gitignore
+++ b/examples/low_consumption/.gitignore
@@ -1,3 +1,5 @@
 build
+managed_components
+dependencies.lock
 sdkconfig
 sdkconfig.old

--- a/examples/multithread_publisher/.gitignore
+++ b/examples/multithread_publisher/.gitignore
@@ -1,3 +1,5 @@
 build
+managed_components
+dependencies.lock
 sdkconfig
 sdkconfig.old

--- a/examples/parameters/.gitignore
+++ b/examples/parameters/.gitignore
@@ -1,3 +1,5 @@
 build
+managed_components
+dependencies.lock
 sdkconfig
 sdkconfig.old

--- a/examples/ping_pong/.gitignore
+++ b/examples/ping_pong/.gitignore
@@ -1,3 +1,5 @@
 build
+managed_components
+dependencies.lock
 sdkconfig
 sdkconfig.old

--- a/idf_component.yml
+++ b/idf_component.yml
@@ -1,0 +1,9 @@
+dependencies:
+  espressif/esp_wifi_remote:
+    version: ">=0.10,<2.0"
+    rules:
+      - if: "target in [esp32p4]"
+  espressif/esp_hosted:
+    version: "~2"
+    rules:
+      - if: "target in [esp32p4]"

--- a/libmicroros.mk
+++ b/libmicroros.mk
@@ -135,20 +135,21 @@ ifeq ($(IDF_TARGET),$(filter $(IDF_TARGET),esp32s2 esp32c3 esp32c6))
 		cd ..; \
 		rm -rf $(UROS_DIR)/atomic_workaround;
 endif
-ifeq ($(IDF_TARGET),$(filter $(IDF_TARGET),esp32))
+# ESP32-S3, ESP32-P4, ESP32: only need workaround in IDF 5.5
+ifeq ($(IDF_TARGET),$(filter $(IDF_TARGET),esp32s3 esp32p4 esp32))
+	@if [ $(IDF_VERSION_MAJOR) -eq 5 ] && [ $(IDF_VERSION_MINOR) -eq 5 ]; then \
 		echo $(UROS_DIR)/atomic_workaround; \
 		mkdir $(UROS_DIR)/atomic_workaround; cd $(UROS_DIR)/atomic_workaround; \
 		$(X_AR) x $(UROS_DIR)/install/lib/librcutils.a; \
 		$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_fetch_add_8; \
-		if [ $(IDF_VERSION_MAJOR) -ge 5 ] && [ $(IDF_VERSION_MINOR) -ge 3 ]; then \
-			$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_load_8; \
-			$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_store_8; \
-			$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_exchange_8; \
-		fi; \
+		$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_load_8; \
+		$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_store_8; \
+		$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_exchange_8; \
 		$(X_AR) rc -s librcutils.a *.obj; \
 		cp -rf librcutils.a  $(UROS_DIR)/install/lib/librcutils.a; \
 		cd ..; \
-		rm -rf $(UROS_DIR)/atomic_workaround;
+		rm -rf $(UROS_DIR)/atomic_workaround; \
+	fi
 endif
 
 $(EXTENSIONS_DIR)/libmicroros.a: $(EXTENSIONS_DIR)/micro_ros_src/install patch_atomic

--- a/network_interfaces/uros_ethernet_netif.c
+++ b/network_interfaces/uros_ethernet_netif.c
@@ -74,20 +74,31 @@ esp_err_t uros_network_interface_initialize(void)
     ESP_ERROR_CHECK(esp_event_loop_create_default());
     esp_netif_config_t cfg = ESP_NETIF_DEFAULT_ETH();
     esp_netif_t *eth_netif = esp_netif_new(&cfg);
-    // Set default handlers to process TCP/IP stuffs
+    // Set default handlers to process TCP/IP stuffs (removed in ESP-IDF 5.5+)
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 0)
     ESP_ERROR_CHECK(esp_eth_set_default_handlers(eth_netif));
+#endif
     // Register user defined event handers
     ESP_ERROR_CHECK(esp_event_handler_register(ETH_EVENT, ESP_EVENT_ANY_ID, &eth_event_handler, NULL));
     ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_ETH_GOT_IP, &got_ip_event_handler, NULL));
 
     eth_mac_config_t mac_config = ETH_MAC_DEFAULT_CONFIG();
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+    eth_esp32_emac_config_t esp32_emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
+#endif
     eth_phy_config_t phy_config = ETH_PHY_DEFAULT_CONFIG();
     phy_config.phy_addr = CONFIG_MICRO_ROS_ETH_PHY_ADDR;
     phy_config.reset_gpio_num = CONFIG_MICRO_ROS_ETH_PHY_RST_GPIO;
 #if CONFIG_MICRO_ROS_USE_INTERNAL_ETHERNET
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 0)
     mac_config.smi_mdc_gpio_num = CONFIG_MICRO_ROS_ETH_MDC_GPIO;
     mac_config.smi_mdio_gpio_num = CONFIG_MICRO_ROS_ETH_MDIO_GPIO;
     esp_eth_mac_t *mac = esp_eth_mac_new_esp32(&mac_config);
+#else
+    esp32_emac_config.smi_gpio.mdc_num = CONFIG_MICRO_ROS_ETH_MDC_GPIO;
+    esp32_emac_config.smi_gpio.mdio_num = CONFIG_MICRO_ROS_ETH_MDIO_GPIO;
+    esp_eth_mac_t *mac = esp_eth_mac_new_esp32(&esp32_emac_config, &mac_config);
+#endif
 #if CONFIG_MICRO_ROS_ETH_PHY_IP101
     esp_eth_phy_t *phy = esp_eth_phy_new_ip101(&phy_config);
 #elif CONFIG_MICRO_ROS_ETH_PHY_RTL8201


### PR DESCRIPTION
Enables micro-ROS to be built for ESP32-P4 microcontroller with hosted ESP32-C6 for WiFi connectivity. It is tested on the following dev. board: https://www.waveshare.com/wiki/ESP32-P4-WIFI6-POE-ETH

<img width="579" height="389" alt="grafik" src="https://github.com/user-attachments/assets/372293ce-7839-445d-8061-9d1236f9c1bb" />

<img width="576" height="694" alt="grafik" src="https://github.com/user-attachments/assets/1d9a6bc4-0e76-4931-b3d2-2e3dd0de5af6" />

<img width="575" height="205" alt="grafik" src="https://github.com/user-attachments/assets/f95ca1e4-113a-46cf-a66b-f0315e44bb5f" />

<img width="937" height="499" alt="grafik" src="https://github.com/user-attachments/assets/bd3b9ebf-2b20-4b16-874f-0497f7bd6f71" />


The changes are basically the same as in pull-request #319 from GitHub user YanKE01:
https://github.com/micro-ROS/micro_ros_espidf_component/pull/319 The needed changes are taken from commit a2756ce on fork: https://github.com/YanKE01/micro_ros_espidf_component/commit/a2756ce2e259a6c5ddc0459c1bacebb2fe7de36a

Signed-off-by: elpresidente1337 <blubb.420@gmail.com>