### PR TITLE
Fix rolling builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ add_dependencies(libmicroros-prebuilt libmicroros_project)
 
 set_target_properties(libmicroros-prebuilt PROPERTIES IMPORTED_LOCATION ${COMPONENT_DIR}/libmicroros.a)
 target_include_directories(libmicroros-prebuilt INTERFACE ${COMPONENT_DIR}/include)
+target_compile_definitions(libmicroros-prebuilt INTERFACE RCL_MICROROS)
 
 file(GLOB include_folders LIST_DIRECTORIES true CONFIGURE_DEPENDS ${COMPONENT_DIR}/include/*)
 foreach(include_folder ${include_folders})
@@ -106,6 +107,7 @@ foreach(include_folder ${include_folders})
     endif()
 endforeach()
 
+target_compile_definitions(${COMPONENT_LIB} PUBLIC RCL_MICROROS)
 add_dependencies(${COMPONENT_LIB} libmicroros-prebuilt)
 target_link_libraries(${COMPONENT_LIB} INTERFACE libmicroros-prebuilt)
 

--- a/examples/handle_static_types/main/main.c
+++ b/examples/handle_static_types/main/main.c
@@ -32,9 +32,10 @@ sensor_msgs__msg__Image msg_static;
 
 uint8_t my_buffer[1000];
 
-void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
+void timer_callback(rcl_timer_t * timer, int64_t last_call_time, uintptr_t arg)
 {
 	RCLC_UNUSED(last_call_time);
+	RCLC_UNUSED(arg);
 	if (timer != NULL) {
 		RCSOFTCHECK(rcl_publish(&publisher, &msg, NULL));
 		RCSOFTCHECK(rcl_publish(&publisher, &msg_static, NULL));

--- a/examples/int32_publisher/main/main.c
+++ b/examples/int32_publisher/main/main.c
@@ -24,9 +24,10 @@
 rcl_publisher_t publisher;
 std_msgs__msg__Int32 msg;
 
-void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
+void timer_callback(rcl_timer_t * timer, int64_t last_call_time, uintptr_t arg)
 {
 	RCLC_UNUSED(last_call_time);
+	RCLC_UNUSED(arg);
 	if (timer != NULL) {
 		printf("Publishing: %d\n", (int) msg.data);
 		RCSOFTCHECK(rcl_publish(&publisher, &msg, NULL));

--- a/examples/int32_publisher_custom_transport/main/main.c
+++ b/examples/int32_publisher_custom_transport/main/main.c
@@ -24,9 +24,10 @@
 rcl_publisher_t publisher;
 std_msgs__msg__Int32 msg;
 
-void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
+void timer_callback(rcl_timer_t * timer, int64_t last_call_time, uintptr_t arg)
 {
 	RCLC_UNUSED(last_call_time);
+	RCLC_UNUSED(arg);
 	if (timer != NULL) {
 		RCSOFTCHECK(rcl_publish(&publisher, &msg, NULL));
 		msg.data++;

--- a/examples/int32_publisher_custom_transport_usbcdc/main/main.c
+++ b/examples/int32_publisher_custom_transport_usbcdc/main/main.c
@@ -51,8 +51,9 @@ rcl_publisher_t publisher; // Publisher
 std_msgs__msg__Int32 msg; // Message to be published
 
 // Timer callback. Publishes a message
-void timer_callback(rcl_timer_t *timer, int64_t last_call_time) {
+void timer_callback(rcl_timer_t *timer, int64_t last_call_time, uintptr_t arg) {
 	RCLC_UNUSED(last_call_time);
+	RCLC_UNUSED(arg);
 	if (timer != NULL) {
 		// Publish message to topic
 		RCSOFTCHECK(rcl_publish(&publisher, &msg, NULL));

--- a/examples/int32_publisher_embeddedrtps/main/main.c
+++ b/examples/int32_publisher_embeddedrtps/main/main.c
@@ -20,9 +20,10 @@
 rcl_publisher_t publisher;
 std_msgs__msg__Int32 msg;
 
-void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
+void timer_callback(rcl_timer_t * timer, int64_t last_call_time, uintptr_t arg)
 {
 	RCLC_UNUSED(last_call_time);
+	RCLC_UNUSED(arg);
 	if (timer != NULL) {
 		printf("Publishing: %d\n", (int) msg.data);
 		RCSOFTCHECK(rcl_publish(&publisher, &msg, NULL));

--- a/examples/int32_sub_pub/main/main.c
+++ b/examples/int32_sub_pub/main/main.c
@@ -26,9 +26,10 @@ rcl_subscription_t subscriber;
 std_msgs__msg__Int32 send_msg;
 std_msgs__msg__Int32 recv_msg;
 
-void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
+void timer_callback(rcl_timer_t * timer, int64_t last_call_time, uintptr_t arg)
 {
 	(void) last_call_time;
+	(void) arg;
 	if (timer != NULL) {
 		RCSOFTCHECK(rcl_publish(&publisher, &send_msg, NULL));
 		printf("Sent: %d\n",  (int)  send_msg.data);

--- a/examples/low_consumption/main/main.c
+++ b/examples/low_consumption/main/main.c
@@ -32,9 +32,10 @@ std_msgs__msg__Int32 msg;
 esp_pm_lock_handle_t pmlock;
 #endif /* CONFIG_PM_ENABLE */
 
-void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
+void timer_callback(rcl_timer_t * timer, int64_t last_call_time, uintptr_t arg)
 {
 	RCLC_UNUSED(last_call_time);
+	RCLC_UNUSED(arg);
 	if (timer != NULL) {
 #ifdef CONFIG_PM_ENABLE
                 esp_pm_lock_acquire(pmlock);	// disable wifi sleep mode

--- a/examples/parameters/main/main.c
+++ b/examples/parameters/main/main.c
@@ -23,10 +23,11 @@
 
 rclc_parameter_server_t param_server;
 
-void timer_callback(rcl_timer_t * timer, int64_t last_call_time)
+void timer_callback(rcl_timer_t * timer, int64_t last_call_time, uintptr_t arg)
 {
     (void) timer;
     (void) last_call_time;
+    (void) arg;
 
     int64_t value;
     rclc_parameter_get_int(&param_server, "param2", &value);

--- a/examples/ping_pong/main/main.c
+++ b/examples/ping_pong/main/main.c
@@ -40,9 +40,10 @@ int device_id;
 int seq_no;
 int pong_count;
 
-void ping_timer_callback(rcl_timer_t * timer, int64_t last_call_time)
+void ping_timer_callback(rcl_timer_t * timer, int64_t last_call_time, uintptr_t arg)
 {
 	RCLC_UNUSED(last_call_time);
+	RCLC_UNUSED(arg);
 
 	if (timer != NULL) {
 

--- a/libmicroros.mk
+++ b/libmicroros.mk
@@ -47,6 +47,8 @@ $(EXTENSIONS_DIR)/micro_ros_dev/install:
 	touch src/ament_cmake_ros/rmw_test_fixture/COLCON_IGNORE; \
 	colcon build --cmake-args -DBUILD_TESTING=OFF -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=gcc;
 
+# ros2/rosidl needs to be pinned to an older version as ros2/rosidl#942 added rosidl_buffer as
+# a dependency for various rosidl packages and we can't build it currently.
 $(EXTENSIONS_DIR)/micro_ros_src/src:
 	rm -rf micro_ros_src; \
 	mkdir micro_ros_src; cd micro_ros_src; \
@@ -58,13 +60,16 @@ $(EXTENSIONS_DIR)/micro_ros_src/src:
 		git clone -b rolling https://github.com/micro-ROS/rmw_microxrcedds src/rmw_microxrcedds; \
 	fi; \
 	git clone -b ros2 https://github.com/eProsima/micro-CDR src/micro-CDR; \
-	git clone -b rolling https://github.com/micro-ROS/rcl src/rcl; \
+	git clone -b upstream-patches https://github.com/micro-ROS/rcl src/rcl; \
 	git clone -b rolling https://github.com/ros2/rclc src/rclc; \
 	git clone -b rolling https://github.com/micro-ROS/rcutils src/rcutils; \
 	git clone -b rolling https://github.com/micro-ROS/micro_ros_msgs src/micro_ros_msgs; \
 	git clone -b rolling https://github.com/micro-ROS/rosidl_typesupport src/rosidl_typesupport; \
 	git clone -b rolling https://github.com/micro-ROS/rosidl_typesupport_microxrcedds src/rosidl_typesupport_microxrcedds; \
 	git clone -b rolling https://github.com/ros2/rosidl src/rosidl; \
+	cd src/rosidl; \
+	git reset --hard 5f4ace0288ecf942307ed62b9239ab5986884676; \
+	cd ../..; \
 	git clone -b rolling https://github.com/ros2/rosidl_dynamic_typesupport src/rosidl_dynamic_typesupport; \
 	git clone -b rolling https://github.com/ros2/rmw src/rmw; \
 	git clone -b rolling https://github.com/ros2/rcl_interfaces src/rcl_interfaces; \
@@ -78,13 +83,16 @@ $(EXTENSIONS_DIR)/micro_ros_src/src:
 	git clone -b rolling https://github.com/ros2/ros2_tracing src/ros2_tracing; \
 	git clone -b rolling https://github.com/micro-ROS/micro_ros_utilities src/micro_ros_utilities; \
 	git clone -b rolling https://github.com/ros2/rosidl_core src/rosidl_core; \
-    touch src/rosidl/rosidl_typesupport_introspection_cpp/COLCON_IGNORE; \
-    touch src/rcl_logging/rcl_logging_log4cxx/COLCON_IGNORE; \
-    touch src/rcl_logging/rcl_logging_spdlog/COLCON_IGNORE; \
-    touch src/rclc/rclc_examples/COLCON_IGNORE; \
 	touch src/rcl/rcl_yaml_param_parser/COLCON_IGNORE; \
-	touch src/ros2_tracing/test_tracetools/COLCON_IGNORE; \
+	touch src/rclc/rclc_examples/COLCON_IGNORE; \
+	touch src/rcl_logging/rcl_logging_implementation/COLCON_IGNORE; \
+	touch src/rcl_logging/rcl_logging_spdlog/COLCON_IGNORE; \
 	touch src/ros2_tracing/lttngpy/COLCON_IGNORE; \
+	touch src/ros2_tracing/test_tracetools/COLCON_IGNORE; \
+	touch src/rosidl/rosidl_buffer/COLCON_IGNORE; \
+	touch src/rosidl/rosidl_buffer_backend/COLCON_IGNORE; \
+	touch src/rosidl/rosidl_buffer_backend_registry/COLCON_IGNORE; \
+	touch src/rosidl/rosidl_typesupport_introspection_cpp/COLCON_IGNORE; \
 	cp -rfL $(EXTRA_ROS_PACKAGES) src/extra_packages || :; \
 	test -f src/extra_packages/extra_packages.repos && cd src/extra_packages && vcs import --input extra_packages.repos || :;
 


### PR DESCRIPTION
Some packages needed to be pinned to older versions, and `COLCON_IGNORE` had to be added to some new ones.
Look at the PR diff for more info.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #325 
- <kbd>&nbsp;3&nbsp;</kbd> #324 
- <kbd>&nbsp;2&nbsp;</kbd> #323 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #329 
<!-- GitButler Footer Boundary Bottom -->

Changes specific to this PR: [`d2c43d8`](https://github.com/micro-ROS/micro_ros_espidf_component/pull/323/commits/d2c43d8ffa59944d854aa45b0b4dd387c0036d83)
