### PR TITLE
Multiple CI and README.md Improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,51 +2,44 @@ name: CI
 
 on:
   pull_request:
+  push:
     branches:
-      - '**'
+      - humble
+      - jazzy
+      - kilted
+      - rolling
+  workflow_call:
+    inputs:
+      branch:
+        description: "Branch to checkout"
+        required: false
+        type: string
+        default: "rolling"
+  workflow_dispatch:
 
 jobs:
-
   micro_ros_idf:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        idf_target: [ esp32, esp32s2, esp32s3, esp32c3, esp32c6]
-        idf_version: [ "espressif/idf:release-v5.2" ]
-        exclude:
-          # Skip IDF v4 + ESP32C6 combination
-          - idf_target: esp32c6
-            idf_version: espressif/idf:release-v4.4
+        idf_target: [esp32, esp32s2, esp32s3, esp32c3, esp32c6]
+        idf_version: [v5.2, v5.3, v5.4]
 
     container:
-      image: ${{ matrix.idf_version }}
+      image: "espressif/idf:release-${{ matrix.idf_version }}"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           path: micro_ros_espidf_component
+          ref: ${{ inputs.branch || github.ref }}
 
       - name: Dependencies
         shell: bash
         run: |
-          apt update
-          export DEBIAN_FRONTEND=noninteractive
-          apt install -y git python3-pip
           . $IDF_PATH/export.sh
-          pip3 install catkin_pkg lark-parser colcon-common-extensions
-          # This line avoids the error when using Python < 3.7 https://importlib-resources.readthedocs.io/en/latest/
-          pip3 install importlib-resources
-          # this installs the modules also for global python interpreter, needed for IDF v5
-          /usr/bin/pip3 install catkin_pkg lark-parser colcon-common-extensions importlib-resources
-
-      # This line can be removed when https://github.com/colcon/colcon-python-setup-py/issues/56 is solved
-      - name: Patch setuptools
-        shell: bash
-        if: matrix.idf_version == 'espressif/idf:release-v4.4'
-        run: |
-          . $IDF_PATH/export.sh
-          pip3 install setuptools==68.1.2
+          pip install catkin_pkg colcon-common-extensions lark
 
       - name: Build sample - int32_publisher
         shell: bash
@@ -86,7 +79,7 @@ jobs:
 
       - name: Build sample - int32_publisher_custom_transport_usbcdc
         shell: bash
-        if: (matrix.idf_target == 'esp32s2' || matrix.idf_target == 'esp32s3') && matrix.idf_version == 'espressif/idf:release-v5.2'
+        if: matrix.idf_target == 'esp32s2' || matrix.idf_target == 'esp32s3'
         run: |
           . $IDF_PATH/export.sh
           cd micro_ros_espidf_component/examples/int32_publisher_custom_transport_usbcdc
@@ -101,15 +94,5 @@ jobs:
           make -f libmicroros.mk clean
           sed -i 's/DRMW_UXRCE_TRANSPORT=udp/DRMW_UXRCE_TRANSPORT=custom/' colcon.meta
           cd examples/multithread_publisher
-          idf.py set-target ${{ matrix.idf_target }}
-          idf.py build
-
-      - name: EmbeddedRTPS
-        shell: bash
-        run: |
-          . $IDF_PATH/export.sh
-          cd micro_ros_espidf_component
-          make -f libmicroros.mk clean
-          cd examples/int32_publisher_embeddedrtps
           idf.py set-target ${{ matrix.idf_target }}
           idf.py build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,117 +1,16 @@
 name: Nightly
 
 on:
-  workflow_dispatch:
-    inputs:
-      name:
-        description: "Manual trigger"
   schedule:
-    - cron:  '0 4 * * *'
+    - cron: '0 4 * * *'
+  workflow_dispatch:
 
 jobs:
   micro_ros_idf:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        branch: [rolling, jazzy, humble]
-        idf_target: [ esp32, esp32s2, esp32c3, esp32s3, esp32c6]
-        idf_version: [ "espressif/idf:release-v4.4", "espressif/idf:release-v5.2" ]
-        exclude:
-          # Skip IDF v4 + ESP32C6 combination
-          - idf_target: esp32c6
-            idf_version: espressif/idf:release-v4.4
-          # Skip IDF v4 for rolling and kilted
-          - branch: rolling
-            idf_version: espressif/idf:release-v4.4
-          - branch: kilted
-            idf_version: espressif/idf:release-v4.4
-
-
-    container:
-      image: ${{ matrix.idf_version }}
-
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          path: micro_ros_espidf_component
-          ref: ${{ matrix.branch }}
-
-      - name: Dependencies
-        shell: bash
-        run: |
-          apt update
-          export DEBIAN_FRONTEND=noninteractive
-          apt install -y git python3-pip
-          . $IDF_PATH/export.sh
-          pip3 install catkin_pkg lark-parser empy==3.3.4 colcon-common-extensions
-          # This line avoids the error when using Python < 3.7 https://importlib-resources.readthedocs.io/en/latest/
-          pip3 install importlib-resources
-          # this installs the modules also for global python interpreter, needed for IDF v5
-          /usr/bin/pip3 install catkin_pkg lark-parser empy==3.3.4 colcon-common-extensions importlib-resources
-
-      # This line can be removed when https://github.com/colcon/colcon-python-setup-py/issues/56 is solved
-      - name: Patch setuptools
-        shell: bash
-        if: matrix.idf_version == 'espressif/idf:release-v4.4'
-        run: |
-          . $IDF_PATH/export.sh
-          pip3 install setuptools==68.1.2
-
-      - name: Build sample - int32_publisher
-        shell: bash
-        run: |
-          . $IDF_PATH/export.sh
-          cd micro_ros_espidf_component/examples/int32_publisher
-          idf.py set-target ${{ matrix.idf_target }}
-          idf.py build
-
-      - name: Build sample - low_consumption
-        shell: bash
-        if: matrix.idf_target != 'esp32c3' && matrix.idf_target != 'esp32s3' && matrix.idf_target != 'esp32c6'
-        run: |
-          . $IDF_PATH/export.sh
-          cd micro_ros_espidf_component/examples/low_consumption
-          idf.py set-target ${{ matrix.idf_target }}
-          idf.py build
-
-      - name: Build sample - handle_static_types
-        shell: bash
-        run: |
-          . $IDF_PATH/export.sh
-          cd micro_ros_espidf_component/examples/handle_static_types
-          idf.py set-target ${{ matrix.idf_target }}
-          idf.py build
-
-      - name: Build sample - int32_publisher_custom_transport
-        shell: bash
-        run: |
-          . $IDF_PATH/export.sh
-          cd micro_ros_espidf_component
-          make -f libmicroros.mk clean
-          sed -i 's/DRMW_UXRCE_TRANSPORT=udp/DRMW_UXRCE_TRANSPORT=custom/' colcon.meta
-          cd examples/int32_publisher_custom_transport
-          idf.py set-target ${{ matrix.idf_target }}
-          idf.py build
-
-      - name: Build sample - multithread_publisher
-        shell: bash
-        run: |
-          . $IDF_PATH/export.sh
-          cd micro_ros_espidf_component
-          make -f libmicroros.mk clean
-          sed -i 's/DRMW_UXRCE_TRANSPORT=udp/DRMW_UXRCE_TRANSPORT=custom/' colcon.meta
-          cd examples/multithread_publisher
-          idf.py set-target ${{ matrix.idf_target }}
-          idf.py build
-
-      - name: EmbeddedRTPS
-        if: ${{ matrix.branch == 'humble' }}
-        shell: bash
-        run: |
-          . $IDF_PATH/export.sh
-          cd micro_ros_espidf_component
-          make -f libmicroros.mk clean
-          cd examples/int32_publisher_embeddedrtps
-          idf.py set-target ${{ matrix.idf_target }}
-          idf.py build
+        branch: [humble, jazzy, kilted, rolling]
+    uses: ./.github/workflows/ci.yml
+    with:
+      branch: ${{ matrix.branch }}

--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 
 # micro-ROS component for ESP-IDF
 
-This component has been tested in ESP-IDF v5.2 with ESP32, ESP32-S2, ESP32-S3, ESP32-C3 and ESP32-C6.
-
-_Note: ESP-IDF v4.4 is supported only in ROS 2 Humble and Jazzy due to Python version incompatibilities._
+This component has been tested in ESP-IDF v5.2, v5.3, and v5.4 with ESP32, ESP32-S2, ESP32-S3, ESP32-C3 and ESP32-C6.
 
 ## Dependencies
 
@@ -13,16 +11,18 @@ This component needs `colcon` and other Python 3 packages inside the IDF virtual
 
 ```bash
 . $IDF_PATH/export.sh
-pip3 install catkin_pkg lark-parser colcon-common-extensions
+pip3 install catkin_pkg colcon-common-extensions lark
 ```
 
 ## Middlewares available
 
 This package support the usage of micro-ROS on top of two different middlewares:
+
 - [eProsima Micro XRCE-DDS](https://micro-xrce-dds.docs.eprosima.com/en/latest/): the default micro-ROS middleware.
-- [embeddedRTPS](https://github.com/embedded-software-laboratory/embeddedRTPS): an experimental implementation of a RTPS middleware compatible with ROS 2.
+- [embeddedRTPS](https://github.com/embedded-software-laboratory/embeddedRTPS): an experimental implementation of a RTPS middleware compatible with ROS 2. (CURRENTLY NOT WORKING)
 
 In order to select it, use `idf.py menuconfig` and go to `micro-ROS Settings > micro-ROS middleware`
+
 ## Usage
 
 You can clone this repo directly in the `components` folder of your project.
@@ -36,7 +36,7 @@ In order to test a int32_publisher example:
 ```bash
 . $IDF_PATH/export.sh
 cd examples/int32_publisher
-# Set target board [esp32|esp32s2|esp32s3|esp32c3]
+# Set target board [esp32|esp32s2|esp32s3|esp32c3|esp32c6]
 idf.py set-target esp32
 idf.py menuconfig
 # Set your micro-ROS configuration and WiFi credentials under micro-ROS Settings
@@ -63,19 +63,16 @@ docker run -it --rm --net=host microros/micro-ros-agent:rolling udp4 --port 8888
 It's possible to build this example application using the official Espressif [docker images](https://hub.docker.com/r/espressif/idf), following the same steps:
 
 ```bash
-docker pull espressif/idf:release-v5.2
-# Run ESP-IDF container
-docker run --name micro-ros-espidf-component-test -it espressif/idf:release-v5.2 bash
+docker run --name micro-ros-espidf-component -it espressif/idf:release-v5.4 bash
 
-git clone https://github.com/micro-ROS/micro_ros_espidf_component.git
+git clone -b rolling https://github.com/micro-ROS/micro_ros_espidf_component.git
 cd micro_ros_espidf_component/
 
 # Install dependencies
-pip3 install catkin_pkg lark-parser colcon-common-extensions
+pip install catkin_pkg colcon-common-extensions lark
 
-$IDF_PATH/export.sh
 cd examples/int32_publisher
-# Set target board [esp32|esp32s2|esp32s3|esp32c3]
+# Set target board [esp32|esp32s2|esp32s3|esp32c3|esp32c6]
 idf.py set-target esp32
 idf.py menuconfig
 # Set your micro-ROS configuration and WiFi credentials under micro-ROS Settings


### PR DESCRIPTION
This PR makes many improvements to the CI and README.md.
The CI builds are a bit faster now and are run for v5.2, v5.3, and v5.4 of ESP-IDF.
I also removed CI compatibility and mentions of ESP-IDF v4.4, as it's been declared EOL by Espressif for a while now.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #325 
- <kbd>&nbsp;3&nbsp;</kbd> #324 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #323 
- <kbd>&nbsp;1&nbsp;</kbd> #329 
<!-- GitButler Footer Boundary Bottom -->

Changes specific to this PR: [`c9c54a8`](https://github.com/micro-ROS/micro_ros_espidf_component/pull/324/commits/c9c54a890e2e5248b7796eb326399a6d78e0a29c)

