### PR TITLE
Add Support for ESP-IDF v5.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         idf_target: [esp32, esp32s2, esp32s3, esp32c3, esp32c6]
-        idf_version: [v5.2, v5.3, v5.4]
+        idf_version: [v5.2, v5.3, v5.4, v5.5]
 
     container:
       image: "espressif/idf:release-${{ matrix.idf_version }}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,10 +71,7 @@ execute_process(
         ${submake} -j -f libmicroros.mk
                 X_CC=${CMAKE_C_COMPILER}
                 X_AR=${CMAKE_AR}
-                X_STRIP=${CMAKE_STRIP}
-                X_CFLAGS=${CMAKE_C_FLAGS}
                 X_CXX=${CMAKE_CXX_COMPILER}
-                X_CXXFLAGS=${CMAKE_CXX_FLAGS}
                 C_STANDARD=${CMAKE_C_STANDARD}
                 MIDDLEWARE=${MIDDLEWARE}
                 BUILD_DIR=${CMAKE_BINARY_DIR}
@@ -82,8 +79,6 @@ execute_process(
                 IDF_PATH=${IDF_PATH}
                 IDF_TARGET=${IDF_TARGET}
                 APP_COLCON_META=${APP_COLCON_META}
-                IDF_VERSION_MAJOR=${IDF_VERSION_MAJOR}
-                IDF_VERSION_MINOR=${IDF_VERSION_MINOR}
                 EXTRA_ROS_PACKAGES=${EXTRA_ROS_PACKAGES}
 )
 if(libmicroros_ret AND NOT libmicroros_ret EQUAL 0)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # micro-ROS component for ESP-IDF
 
-This component has been tested in ESP-IDF v5.2, v5.3, and v5.4 with ESP32, ESP32-S2, ESP32-S3, ESP32-C3 and ESP32-C6.
+This component has been tested in ESP-IDF v5.2, v5.3, v5.4, and v5.5 with ESP32, ESP32-S2, ESP32-S3, ESP32-C3 and ESP32-C6.
 
 ## Dependencies
 
@@ -63,7 +63,7 @@ docker run -it --rm --net=host microros/micro-ros-agent:rolling udp4 --port 8888
 It's possible to build this example application using the official Espressif [docker images](https://hub.docker.com/r/espressif/idf), following the same steps:
 
 ```bash
-docker run --name micro-ros-espidf-component -it espressif/idf:release-v5.4 bash
+docker run --name micro-ros-espidf-component -it espressif/idf:release-v5.5 bash
 
 git clone -b rolling https://github.com/micro-ROS/micro_ros_espidf_component.git
 cd micro_ros_espidf_component/

--- a/libmicroros.mk
+++ b/libmicroros.mk
@@ -10,9 +10,6 @@ else
 	BUILD_TYPE = Release
 endif
 
-CFLAGS_INTERNAL := $(X_CFLAGS) -ffunction-sections -fdata-sections
-CXXFLAGS_INTERNAL := $(X_CXXFLAGS) -ffunction-sections -fdata-sections
-
 all: $(EXTENSIONS_DIR)/libmicroros.a
 
 clean:
@@ -27,8 +24,6 @@ $(EXTENSIONS_DIR)/esp32_toolchain.cmake: $(EXTENSIONS_DIR)/esp32_toolchain.cmake
 	cat $(EXTENSIONS_DIR)/esp32_toolchain.cmake.in | \
 		sed "s/@CMAKE_C_COMPILER@/$(subst /,\/,$(X_CC))/g" | \
 		sed "s/@CMAKE_CXX_COMPILER@/$(subst /,\/,$(X_CXX))/g" | \
-		sed "s/@CFLAGS@/$(subst /,\/,$(CFLAGS_INTERNAL))/g" | \
-		sed "s/@CXXFLAGS@/$(subst /,\/,$(CXXFLAGS_INTERNAL))/g" | \
 		sed "s/@IDF_TARGET@/$(subst /,\/,$(IDF_TARGET))/g" | \
 		sed "s/@IDF_PATH@/$(subst /,\/,$(IDF_PATH))/g" | \
 		sed "s/@BUILD_CONFIG_DIR@/$(subst /,\/,$(BUILD_DIR)/config)/g" \

--- a/network_interfaces/uros_ethernet_netif.c
+++ b/network_interfaces/uros_ethernet_netif.c
@@ -74,20 +74,31 @@ esp_err_t uros_network_interface_initialize(void)
     ESP_ERROR_CHECK(esp_event_loop_create_default());
     esp_netif_config_t cfg = ESP_NETIF_DEFAULT_ETH();
     esp_netif_t *eth_netif = esp_netif_new(&cfg);
-    // Set default handlers to process TCP/IP stuffs
+    // Set default handlers to process TCP/IP stuffs (removed in ESP-IDF 5.5+)
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 0)
     ESP_ERROR_CHECK(esp_eth_set_default_handlers(eth_netif));
+#endif
     // Register user defined event handers
     ESP_ERROR_CHECK(esp_event_handler_register(ETH_EVENT, ESP_EVENT_ANY_ID, &eth_event_handler, NULL));
     ESP_ERROR_CHECK(esp_event_handler_register(IP_EVENT, IP_EVENT_ETH_GOT_IP, &got_ip_event_handler, NULL));
 
     eth_mac_config_t mac_config = ETH_MAC_DEFAULT_CONFIG();
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 5, 0)
+    eth_esp32_emac_config_t esp32_emac_config = ETH_ESP32_EMAC_DEFAULT_CONFIG();
+#endif
     eth_phy_config_t phy_config = ETH_PHY_DEFAULT_CONFIG();
     phy_config.phy_addr = CONFIG_MICRO_ROS_ETH_PHY_ADDR;
     phy_config.reset_gpio_num = CONFIG_MICRO_ROS_ETH_PHY_RST_GPIO;
 #if CONFIG_MICRO_ROS_USE_INTERNAL_ETHERNET
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 5, 0)
     mac_config.smi_mdc_gpio_num = CONFIG_MICRO_ROS_ETH_MDC_GPIO;
     mac_config.smi_mdio_gpio_num = CONFIG_MICRO_ROS_ETH_MDIO_GPIO;
     esp_eth_mac_t *mac = esp_eth_mac_new_esp32(&mac_config);
+#else
+    esp32_emac_config.smi_gpio.mdc_num = CONFIG_MICRO_ROS_ETH_MDC_GPIO;
+    esp32_emac_config.smi_gpio.mdio_num = CONFIG_MICRO_ROS_ETH_MDIO_GPIO;
+    esp_eth_mac_t *mac = esp_eth_mac_new_esp32(&esp32_emac_config, &mac_config);
+#endif
 #if CONFIG_MICRO_ROS_ETH_PHY_IP101
     esp_eth_phy_t *phy = esp_eth_phy_new_ip101(&phy_config);
 #elif CONFIG_MICRO_ROS_ETH_PHY_RTL8201


### PR DESCRIPTION
The changes were mostly taken from #319 / #322, but ported to rolling. I will add support for ESP32-P4 in a separate PR.

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #325 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #324 
- <kbd>&nbsp;2&nbsp;</kbd> #323 
- <kbd>&nbsp;1&nbsp;</kbd> #329 
<!-- GitButler Footer Boundary Bottom -->

Changes specific to this PR: [`e747951`](https://github.com/micro-ROS/micro_ros_espidf_component/pull/325/commits/e747951f7b6f72958a1eed3295336bb46900cb9d)

