### PR TITLE
Remove atomic patch & sed for flags, add support for idf 5.3, 5.4 (Humble)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,12 @@ jobs:
       fail-fast: false
       matrix:
         idf_target: [ esp32, esp32s2, esp32s3, esp32c3, esp32c6, esp32p4]
-        idf_version: [ "espressif/idf:release-v4.4", "espressif/idf:release-v5.2", "espressif/idf:release-v5.5" ]
+        idf_version:
+          - "espressif/idf:release-v4.4"
+          - "espressif/idf:release-v5.2"
+          - "espressif/idf:release-v5.3"
+          - "espressif/idf:release-v5.4"
+          - "espressif/idf:release-v5.5"
         exclude:
           # Skip IDF v4 + ESP32C6 combination
           - idf_target: esp32c6
@@ -44,8 +49,8 @@ jobs:
           # This line avoids the error when using Python < 3.7 https://importlib-resources.readthedocs.io/en/latest/
           pip3 install importlib-resources
           # this installs the modules also for global python interpreter, needed for IDF v5
-          # IDF 5.5 uses Python 3.12 which has externally-managed-environment protection
-          if [ "${{ matrix.idf_version }}" == "espressif/idf:release-v5.5" ]; then \
+          # IDF 5.4, 5.5 uses Python 3.12 which has externally-managed-environment protection
+          if [ "${{ matrix.idf_version }}" == "espressif/idf:release-v5.4" ] || [ "${{ matrix.idf_version }}" == "espressif/idf:release-v5.5" ]; then \
             /usr/bin/pip3 install --break-system-packages catkin_pkg lark-parser colcon-common-extensions empy==3.3.4 importlib-resources; \
           else \
             /usr/bin/pip3 install catkin_pkg lark-parser colcon-common-extensions empy==3.3.4 importlib-resources; \

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,12 @@ jobs:
       matrix:
         branch: [rolling, jazzy, humble]
         idf_target: [ esp32, esp32s2, esp32c3, esp32s3, esp32c6, esp32p4]
-        idf_version: [ "espressif/idf:release-v4.4", "espressif/idf:release-v5.2", "espressif/idf:release-v5.5" ]
+        idf_version:
+          - "espressif/idf:release-v4.4"
+          - "espressif/idf:release-v5.2"
+          - "espressif/idf:release-v5.3"
+          - "espressif/idf:release-v5.4"
+          - "espressif/idf:release-v5.5"
         exclude:
           # Skip IDF v4 + ESP32C6 combination
           - idf_target: esp32c6
@@ -49,8 +54,8 @@ jobs:
           # This line avoids the error when using Python < 3.7 https://importlib-resources.readthedocs.io/en/latest/
           pip3 install importlib-resources
           # this installs the modules also for global python interpreter, needed for IDF v5
-          # IDF 5.5 uses Python 3.12 which has externally-managed-environment protection
-          if [ "${{ matrix.idf_version }}" == "espressif/idf:release-v5.5" ]; then \
+          # IDF 5.4, 5.5 uses Python 3.12 which has externally-managed-environment protection
+          if [ "${{ matrix.idf_version }}" == "espressif/idf:release-v5.4" ] || [ "${{ matrix.idf_version }}" == "espressif/idf:release-v5.5" ]; then \
             /usr/bin/pip3 install --break-system-packages catkin_pkg lark-parser colcon-common-extensions importlib-resources; \
           else \
             /usr/bin/pip3 install catkin_pkg lark-parser colcon-common-extensions importlib-resources; \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,10 +71,7 @@ execute_process(
         ${submake} -j -f libmicroros.mk
                 X_CC=${CMAKE_C_COMPILER}
                 X_AR=${CMAKE_AR}
-                X_STRIP=${CMAKE_STRIP}
-                X_CFLAGS=${CMAKE_C_FLAGS}
                 X_CXX=${CMAKE_CXX_COMPILER}
-                X_CXXFLAGS=${CMAKE_CXX_FLAGS}
                 C_STANDARD=${CMAKE_C_STANDARD}
                 MIDDLEWARE=${MIDDLEWARE}
                 BUILD_DIR=${CMAKE_BINARY_DIR}
@@ -82,8 +79,6 @@ execute_process(
                 IDF_PATH=${IDF_PATH}
                 IDF_TARGET=${IDF_TARGET}
                 APP_COLCON_META=${APP_COLCON_META}
-                IDF_VERSION_MAJOR=${IDF_VERSION_MAJOR}
-                IDF_VERSION_MINOR=${IDF_VERSION_MINOR}
                 EXTRA_ROS_PACKAGES=${EXTRA_ROS_PACKAGES}
 )
 if(libmicroros_ret AND NOT libmicroros_ret EQUAL 0)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # micro-ROS component for ESP-IDF
 
-This component has been tested in ESP-IDF v4.4, v5.2, and v5.5 with ESP32, ESP32-S2, ESP32-S3, ESP32-C3, ESP32-C6 and ESP32-P4.
+This component has been tested in ESP-IDF v4.4, v5.2, v5.3, v5.4, and v5.5 with ESP32, ESP32-S2, ESP32-S3, ESP32-C3, ESP32-C6 and ESP32-P4.
 
 ## Dependencies
 

--- a/colcon.meta
+++ b/colcon.meta
@@ -18,7 +18,7 @@
                 "-DENABLE_TESTING=OFF",
                 "-DRCUTILS_NO_FILESYSTEM=ON",
                 "-DRCUTILS_NO_THREAD_SUPPORT=ON",
-                "-DRCUTILS_NO_64_ATOMIC=ON",
+                "-DRCUTILS_NO_64_ATOMIC=OFF",
                 "-DRCUTILS_AVOID_DYNAMIC_ALLOCATION=ON"
             ]
         },

--- a/libmicroros.mk
+++ b/libmicroros.mk
@@ -10,8 +10,6 @@ else
 	BUILD_TYPE = Release
 endif
 
-CFLAGS_INTERNAL := $(X_CFLAGS) -ffunction-sections -fdata-sections
-CXXFLAGS_INTERNAL := $(X_CXXFLAGS) -ffunction-sections -fdata-sections
 
 all: $(EXTENSIONS_DIR)/libmicroros.a
 
@@ -27,8 +25,6 @@ $(EXTENSIONS_DIR)/esp32_toolchain.cmake: $(EXTENSIONS_DIR)/esp32_toolchain.cmake
 	cat $(EXTENSIONS_DIR)/esp32_toolchain.cmake.in | \
 		sed "s/@CMAKE_C_COMPILER@/$(subst /,\/,$(X_CC))/g" | \
 		sed "s/@CMAKE_CXX_COMPILER@/$(subst /,\/,$(X_CXX))/g" | \
-		sed "s/@CFLAGS@/$(subst /,\/,$(CFLAGS_INTERNAL))/g" | \
-		sed "s/@CXXFLAGS@/$(subst /,\/,$(CXXFLAGS_INTERNAL))/g" | \
 		sed "s/@IDF_TARGET@/$(subst /,\/,$(IDF_TARGET))/g" | \
 		sed "s/@IDF_PATH@/$(subst /,\/,$(IDF_PATH))/g" | \
 		sed "s/@BUILD_CONFIG_DIR@/$(subst /,\/,$(BUILD_DIR)/config)/g" \
@@ -105,50 +101,7 @@ $(EXTENSIONS_DIR)/micro_ros_src/install: $(EXTENSIONS_DIR)/esp32_toolchain.cmake
 		-DCMAKE_C_STANDARD=$(C_STANDARD) \
 		-DUCLIENT_C_STANDARD=$(C_STANDARD);
 
-patch_atomic:$(EXTENSIONS_DIR)/micro_ros_src/install
-# Workaround https://github.com/micro-ROS/micro_ros_espidf_component/issues/18
-ifeq ($(IDF_TARGET),$(filter $(IDF_TARGET),esp32s2 esp32c3 esp32c6))
-		echo $(UROS_DIR)/atomic_workaround; \
-		mkdir $(UROS_DIR)/atomic_workaround; cd $(UROS_DIR)/atomic_workaround; \
-		$(X_AR) x $(UROS_DIR)/install/lib/librcutils.a; \
-		$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_fetch_add_8; \
-		if [ $(IDF_VERSION_MAJOR) -ge 4 ] && [ $(IDF_VERSION_MINOR) -ge 3 ]; then \
-			$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_load_8; \
-			$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_store_8; \
-			$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_exchange_8; \
-		fi; \
-		if [ $(IDF_VERSION_MAJOR) -ge 4 ] && [ $(IDF_VERSION_MINOR) -ge 4 ]; then \
-			$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_load_8; \
-			$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_store_8; \
-		fi; \
-		if [ $(IDF_VERSION_MAJOR) -ge 5 ] && [ $(IDF_VERSION_MINOR) -ge 0 ]; then \
-			$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_load_8; \
-			$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_store_8; \
-			$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_exchange_8; \
-		fi; \
-		$(X_AR) rc -s librcutils.a *.obj; \
-		cp -rf librcutils.a  $(UROS_DIR)/install/lib/librcutils.a; \
-		cd ..; \
-		rm -rf $(UROS_DIR)/atomic_workaround;
-endif
-# ESP32-S3, ESP32-P4, ESP32: only need workaround in IDF 5.5
-ifeq ($(IDF_TARGET),$(filter $(IDF_TARGET),esp32s3 esp32p4 esp32))
-	@if [ $(IDF_VERSION_MAJOR) -eq 5 ] && [ $(IDF_VERSION_MINOR) -eq 5 ]; then \
-		echo $(UROS_DIR)/atomic_workaround; \
-		mkdir $(UROS_DIR)/atomic_workaround; cd $(UROS_DIR)/atomic_workaround; \
-		$(X_AR) x $(UROS_DIR)/install/lib/librcutils.a; \
-		$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_fetch_add_8; \
-		$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_load_8; \
-		$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_store_8; \
-		$(X_STRIP) atomic_64bits.c.obj --strip-symbol=__atomic_exchange_8; \
-		$(X_AR) rc -s librcutils.a *.obj; \
-		cp -rf librcutils.a  $(UROS_DIR)/install/lib/librcutils.a; \
-		cd ..; \
-		rm -rf $(UROS_DIR)/atomic_workaround; \
-	fi
-endif
-
-$(EXTENSIONS_DIR)/libmicroros.a: $(EXTENSIONS_DIR)/micro_ros_src/install patch_atomic
+$(EXTENSIONS_DIR)/libmicroros.a: $(EXTENSIONS_DIR)/micro_ros_src/install
 	mkdir -p $(UROS_DIR)/libmicroros; cd $(UROS_DIR)/libmicroros; \
 	for file in $$(find $(UROS_DIR)/install/lib/ -name '*.a'); do \
 		folder=$$(echo $$file | sed -E "s/(.+)\/(.+).a/\2/"); \


### PR DESCRIPTION
Since newer versions of ESP-IDF provide complete atomic operations, we can disable the 64-bit atomic extension in `micro-ROS/rcutils` and remove the complex `patch_atomic` mechanism. See #251.

Remove unnecessary `sed` commands in `libmicroros.mk` to ensure compatibility with ESP-IDF 5.5.4. See #327.

Added support for ESP-IDF 5.3 and 5.4 (already verified through [CI checks in my fork](https://github.com/Narukara/micro_ros_espidf_component/pull/1/checks)).