### PR TITLE
ci: Create mergify.yml for pull request management

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,7 +1,7 @@
 pull_request_rules:
   - name: Backport to humble at the reviewer's discretion
     conditions:
-      - base=master
+      - base=rolling
       - "label=backport-humble"
     actions:
       backport:
@@ -10,7 +10,7 @@ pull_request_rules:
 
   - name: Backport to jazzy at the reviewer's discretion
     conditions:
-      - base=master
+      - base=rolling
       - "label=backport-jazzy"
     actions:
       backport:
@@ -19,7 +19,7 @@ pull_request_rules:
 
   - name: Backport to kilted at the reviewer's discretion
     conditions:
-      - base=master
+      - base=rolling
       - "label=backport-kilted"
     actions:
       backport:

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,54 @@
+pull_request_rules:
+  - name: Backport to humble at the reviewer's discretion
+    conditions:
+      - base=master
+      - "label=backport-humble"
+    actions:
+      backport:
+        branches:
+          - humble
+
+  - name: Backport to jazzy at the reviewer's discretion
+    conditions:
+      - base=master
+      - "label=backport-jazzy"
+    actions:
+      backport:
+        branches:
+          - jazzy
+
+  - name: Backport to kilted at the reviewer's discretion
+    conditions:
+      - base=master
+      - "label=backport-kilted"
+    actions:
+      backport:
+        branches:
+          - kilted
+
+  - name: Ask to resolve conflict
+    conditions:
+      - conflict
+      - author!=mergify[bot]
+    actions:
+        comment:
+          message: This pull request is in conflict. Could you fix it @{{author}}?
+
+  - name: Ask to resolve conflict for backports
+    conditions:
+      - conflict
+      - author=mergify[bot]
+    actions:
+        comment:
+          message: This pull request is in conflict. Could you fix it @Amronos @Narukara?
+
+  - name: Development targets rolling branch
+    conditions:
+      - base!=rolling
+      - author!=mergify[bot]
+    actions:
+        comment:
+          message: |
+            @{{author}}, all pull requests must be targeted towards the `rolling` development branch.
+            Once merged into `rolling`, it is possible to backport to `{{base}}`, but it must be in `rolling`
+            to have these changes reflected in new distributions.


### PR DESCRIPTION
Adds Mergify configuration to streamline backport creation and conflict resolution.
After this PR is merged, could the default branch of this repository be set to `rolling`?