### PR TITLE
fix humble dependencies issue in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,17 @@ jobs:
 
       - name: Dependencies
         shell: bash
+        env:
+          TARGET_BRANCH: ${{ inputs.branch || github.base_ref || github.ref_name }}
         run: |
           . $IDF_PATH/export.sh
-          pip install catkin_pkg colcon-common-extensions lark
+          echo "::notice::TARGET_BRANCH=$TARGET_BRANCH"
+          if [ "$TARGET_BRANCH" = "humble" ]; then
+            python3 -m pip uninstall -y em empy || true
+            python3 -m pip install catkin_pkg colcon-common-extensions lark "empy==3.3.4"
+          else
+            python3 -m pip install catkin_pkg colcon-common-extensions lark
+          fi
 
       - name: Build sample - int32_publisher
         shell: bash


### PR DESCRIPTION
All Nightly CI jobs on the humble branch are failing. Error log:

```
--- stderr: builtin_interfaces
CMake Error at /__w/micro_ros_espidf_component/micro_ros_espidf_component/micro_ros_espidf_component/micro_ros_src/install/share/rosidl_adapter/cmake/rosidl_adapt_interfaces.cmake:59 (message):
  execute_process(/opt/esp/python_env/idf5.4_py3.12_env/bin/python3 -m
  rosidl_adapter --package-name builtin_interfaces --arguments-file
  /__w/micro_ros_espidf_component/micro_ros_espidf_component/micro_ros_espidf_component/micro_ros_src/build/builtin_interfaces/rosidl_adapter__arguments__builtin_interfaces.json
  --output-dir
  /__w/micro_ros_espidf_component/micro_ros_espidf_component/micro_ros_espidf_component/micro_ros_src/build/builtin_interfaces/rosidl_adapter/builtin_interfaces
  --output-file
  /__w/micro_ros_espidf_component/micro_ros_espidf_component/micro_ros_espidf_component/micro_ros_src/build/builtin_interfaces/rosidl_adapter/builtin_interfaces.idls)
  returned error code 1:

  AttributeError processing template 'msg.idl.em'

  Traceback (most recent call last):

    File "/__w/micro_ros_espidf_component/micro_ros_espidf_component/micro_ros_espidf_component/micro_ros_src/install/lib/python3.12/site-packages/rosidl_adapter/resource/__init__.py", line 51, in evaluate_template
      em.BUFFERED_OPT: True,
      ^^^^^^^^^^^^^^^

  AttributeError: module 'em' has no attribute 'BUFFERED_OPT'
```

This is likely due to an `empy` version issue. See: https://github.com/micro-ROS/micro-ROS-Agent/issues/232