### PR TITLE
build: Remove ROS 2 packages that aren't needed

### DIFF
--- a/EXCLUDED_PACKAGES.md
+++ b/EXCLUDED_PACKAGES.md
@@ -1,0 +1,42 @@
+# Excluded ROS 2 Packages
+
+After cloning, [`libmicroros.mk`](./libmicroros.mk) removes the packages below from the workspace before building [`libmicroros.a`](./libmicroros.a).
+
+[`tracetools`](https://github.com/ros2/ros2_tracing/tree/rolling/tracetools) is kept because `rcl` depends on it at build time (tracing is disabled via [`colcon.meta`](./colcon.meta)).
+
+## Can't Build Yet (Need Upstream Patches)
+
+- [`rosidl_buffer`](https://github.com/ros2/rosidl/tree/rolling/rosidl_buffer)
+- [`rosidl_buffer_backend`](https://github.com/ros2/rosidl/tree/rolling/rosidl_buffer_backend)
+- [`rosidl_buffer_backend_registry`](https://github.com/ros2/rosidl/tree/rolling/rosidl_buffer_backend_registry)
+
+[`rosidl`](https://github.com/ros2/rosidl) is pinned to an older commit until [`ros2/rosidl#942`](https://github.com/ros2/rosidl/pull/942) can be built for microcontrollers.
+
+## Not Useful for Micro-ROS
+
+- [`common_interfaces`](https://github.com/ros2/common_interfaces/tree/rolling/common_interfaces)
+- [`lttngpy`](https://github.com/ros2/ros2_tracing/tree/rolling/lttngpy)
+- [`rcl_lifecycle`](https://github.com/micro-ROS/rcl/tree/upstream-patches/rcl_lifecycle)
+- [`rcl_yaml_param_parser`](https://github.com/micro-ROS/rcl/tree/upstream-patches/rcl_yaml_param_parser)
+- [`rcl_logging_implementation`](https://github.com/ros2/rcl_logging/tree/rolling/rcl_logging_implementation)
+- [`rcl_logging_spdlog`](https://github.com/ros2/rcl_logging/tree/rolling/rcl_logging_spdlog)
+- [`rclc_examples`](https://github.com/ros2/rclc/tree/rolling/rclc_examples)
+- [`rclc_lifecycle`](https://github.com/ros2/rclc/tree/rolling/rclc_lifecycle)
+- [`rmw_security_common`](https://github.com/ros2/rmw/tree/rolling/rmw_security_common)
+- [`rmw_test_fixture`](https://github.com/ros2/ament_cmake_ros/tree/rolling/rmw_test_fixture)
+- [`rmw_test_fixture_implementation`](https://github.com/ros2/ament_cmake_ros/tree/rolling/rmw_test_fixture_implementation)
+- [`ros2trace`](https://github.com/ros2/ros2_tracing/tree/rolling/ros2trace)
+- [`rosidl_generator_tests`](https://github.com/ros2/rosidl/tree/rolling/rosidl_generator_tests)
+- [`rosidl_typesupport_introspection_cpp`](https://github.com/ros2/rosidl/tree/rolling/rosidl_typesupport_introspection_cpp)
+- [`rosidl_typesupport_introspection_tests`](https://github.com/ros2/rosidl/tree/rolling/rosidl_typesupport_introspection_tests)
+- [`rosidl_typesupport_microxrcedds/test`](https://github.com/micro-ROS/rosidl_typesupport_microxrcedds/tree/rolling/test)
+- [`rosidl_typesupport_tests`](https://github.com/micro-ROS/rosidl_typesupport/tree/rolling/rosidl_typesupport_tests)
+- [`sensor_msgs_py`](https://github.com/ros2/common_interfaces/tree/rolling/sensor_msgs_py)
+- [`test_rmw_implementation`](https://github.com/ros2/rmw_implementation/tree/rolling/test_rmw_implementation)
+- [`test_ros2trace`](https://github.com/ros2/ros2_tracing/tree/rolling/test_ros2trace)
+- [`test_tracetools`](https://github.com/ros2/ros2_tracing/tree/rolling/test_tracetools)
+- [`test_tracetools_launch`](https://github.com/ros2/ros2_tracing/tree/rolling/test_tracetools_launch)
+- [`tracetools_launch`](https://github.com/ros2/ros2_tracing/tree/rolling/tracetools_launch)
+- [`tracetools_read`](https://github.com/ros2/ros2_tracing/tree/rolling/tracetools_read)
+- [`tracetools_test`](https://github.com/ros2/ros2_tracing/tree/rolling/tracetools_test)
+- [`tracetools_trace`](https://github.com/ros2/ros2_tracing/tree/rolling/tracetools_trace)

--- a/libmicroros.mk
+++ b/libmicroros.mk
@@ -32,14 +32,15 @@ $(EXTENSIONS_DIR)/esp32_toolchain.cmake: $(EXTENSIONS_DIR)/esp32_toolchain.cmake
 $(EXTENSIONS_DIR)/micro_ros_dev/install:
 	rm -rf micro_ros_dev; \
 	mkdir micro_ros_dev; cd micro_ros_dev; \
-	git clone -b rolling https://github.com/ament/ament_cmake src/ament_cmake; \
-	git clone -b rolling https://github.com/ament/ament_lint src/ament_lint; \
-	git clone -b rolling https://github.com/ament/ament_package src/ament_package; \
-	git clone -b rolling https://github.com/ament/googletest src/googletest; \
-	git clone -b rolling https://github.com/ros2/ament_cmake_ros src/ament_cmake_ros; \
-	git clone -b rolling https://github.com/ament/ament_index src/ament_index; \
-	touch src/ament_cmake_ros/rmw_test_fixture_implementation/COLCON_IGNORE; \
-	touch src/ament_cmake_ros/rmw_test_fixture/COLCON_IGNORE; \
+	git clone -b rolling https://github.com/ament/ament_cmake src/ament/ament_cmake; \
+	git clone -b rolling https://github.com/ament/ament_index src/ament/ament_index; \
+	git clone -b rolling https://github.com/ament/ament_lint src/ament/ament_lint; \
+	git clone -b rolling https://github.com/ament/ament_package src/ament/ament_package; \
+	git clone -b rolling https://github.com/ament/googletest src/ament/googletest; \
+	git clone -b rolling https://github.com/ros2/ament_cmake_ros src/ros2/ament_cmake_ros; \
+	set -e; \
+	rm -r src/ros2/ament_cmake_ros/rmw_test_fixture; \
+	rm -r src/ros2/ament_cmake_ros/rmw_test_fixture_implementation; \
 	colcon build --cmake-args -DBUILD_TESTING=OFF -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=gcc;
 
 # ros2/rosidl needs to be pinned to an older version as ros2/rosidl#942 added rosidl_buffer as
@@ -48,46 +49,64 @@ $(EXTENSIONS_DIR)/micro_ros_src/src:
 	rm -rf micro_ros_src; \
 	mkdir micro_ros_src; cd micro_ros_src; \
 	if [ "$(MIDDLEWARE)" = "embeddedrtps" ]; then \
-		git clone -b main https://github.com/micro-ROS/embeddedRTPS src/embeddedRTPS; \
-		git clone -b main https://github.com/micro-ROS/rmw_embeddedrtps src/rmw_embeddedrtps; \
+		git clone -b main https://github.com/micro-ROS/embeddedRTPS src/micro-ROS/embeddedRTPS; \
+		git clone -b main https://github.com/micro-ROS/rmw_embeddedrtps src/micro-ROS/rmw_embeddedrtps; \
 	else \
-		git clone -b ros2 https://github.com/eProsima/Micro-XRCE-DDS-Client src/Micro-XRCE-DDS-Client; \
-		git clone -b rolling https://github.com/micro-ROS/rmw_microxrcedds src/rmw_microxrcedds; \
+		git clone -b ros2 https://github.com/eProsima/Micro-XRCE-DDS-Client src/eProsima/Micro-XRCE-DDS-Client; \
+		git clone -b rolling https://github.com/micro-ROS/rmw_microxrcedds src/micro-ROS/rmw_microxrcedds; \
 	fi; \
-	git clone -b ros2 https://github.com/eProsima/micro-CDR src/micro-CDR; \
-	git clone -b upstream-patches https://github.com/micro-ROS/rcl src/rcl; \
-	git clone -b rolling https://github.com/ros2/rclc src/rclc; \
-	git clone -b rolling https://github.com/micro-ROS/rcutils src/rcutils; \
-	git clone -b rolling https://github.com/micro-ROS/micro_ros_msgs src/micro_ros_msgs; \
-	git clone -b rolling https://github.com/micro-ROS/rosidl_typesupport src/rosidl_typesupport; \
-	git clone -b rolling https://github.com/micro-ROS/rosidl_typesupport_microxrcedds src/rosidl_typesupport_microxrcedds; \
-	git clone -b rolling https://github.com/ros2/rosidl src/rosidl; \
-	cd src/rosidl; \
+	git clone -b ros2 https://github.com/eProsima/micro-CDR src/eProsima/micro-CDR; \
+	git clone -b rolling https://github.com/micro-ROS/micro_ros_msgs src/micro-ROS/micro_ros_msgs; \
+	git clone -b rolling https://github.com/micro-ROS/micro_ros_utilities src/micro-ROS/micro_ros_utilities; \
+	git clone -b upstream-patches https://github.com/micro-ROS/rcl src/micro-ROS/rcl; \
+	git clone -b rolling https://github.com/micro-ROS/rcutils src/micro-ROS/rcutils; \
+	git clone -b rolling https://github.com/micro-ROS/rosidl_typesupport src/micro-ROS/rosidl_typesupport; \
+	git clone -b rolling https://github.com/micro-ROS/rosidl_typesupport_microxrcedds src/micro-ROS/rosidl_typesupport_microxrcedds; \
+	git clone -b rolling https://github.com/ros2/common_interfaces src/ros2/common_interfaces; \
+	git clone -b rolling https://github.com/ros2/example_interfaces src/ros2/example_interfaces; \
+	git clone -b rolling https://github.com/ros2/rcl_interfaces src/ros2/rcl_interfaces; \
+	git clone -b rolling https://github.com/ros2/rcl_logging src/ros2/rcl_logging; \
+	git clone -b rolling https://github.com/ros2/rclc src/ros2/rclc; \
+	git clone -b rolling https://github.com/ros2/rmw src/ros2/rmw; \
+	git clone -b rolling https://github.com/ros2/rmw_implementation src/ros2/rmw_implementation; \
+	git clone -b rolling https://github.com/ros2/ros2_tracing src/ros2/ros2_tracing; \
+	git clone -b rolling https://github.com/ros2/rosidl src/ros2/rosidl; \
+	cd src/ros2/rosidl; \
 	git reset --hard 5f4ace0288ecf942307ed62b9239ab5986884676; \
-	cd ../..; \
-	git clone -b rolling https://github.com/ros2/rosidl_dynamic_typesupport src/rosidl_dynamic_typesupport; \
-	git clone -b rolling https://github.com/ros2/rmw src/rmw; \
-	git clone -b rolling https://github.com/ros2/rcl_interfaces src/rcl_interfaces; \
-	git clone -b rolling https://github.com/ros2/rosidl_defaults src/rosidl_defaults; \
-	git clone -b rolling https://github.com/ros2/unique_identifier_msgs src/unique_identifier_msgs; \
-	git clone -b rolling https://github.com/ros2/common_interfaces src/common_interfaces; \
-	git clone -b rolling https://github.com/ros2/example_interfaces src/example_interfaces; \
-	git clone -b rolling https://github.com/ros2/test_interface_files src/test_interface_files; \
-	git clone -b rolling https://github.com/ros2/rmw_implementation src/rmw_implementation; \
-	git clone -b rolling https://github.com/ros2/rcl_logging src/rcl_logging; \
-	git clone -b rolling https://github.com/ros2/ros2_tracing src/ros2_tracing; \
-	git clone -b rolling https://github.com/micro-ROS/micro_ros_utilities src/micro_ros_utilities; \
-	git clone -b rolling https://github.com/ros2/rosidl_core src/rosidl_core; \
-	touch src/rcl/rcl_yaml_param_parser/COLCON_IGNORE; \
-	touch src/rclc/rclc_examples/COLCON_IGNORE; \
-	touch src/rcl_logging/rcl_logging_implementation/COLCON_IGNORE; \
-	touch src/rcl_logging/rcl_logging_spdlog/COLCON_IGNORE; \
-	touch src/ros2_tracing/lttngpy/COLCON_IGNORE; \
-	touch src/ros2_tracing/test_tracetools/COLCON_IGNORE; \
-	touch src/rosidl/rosidl_buffer/COLCON_IGNORE; \
-	touch src/rosidl/rosidl_buffer_backend/COLCON_IGNORE; \
-	touch src/rosidl/rosidl_buffer_backend_registry/COLCON_IGNORE; \
-	touch src/rosidl/rosidl_typesupport_introspection_cpp/COLCON_IGNORE; \
+	cd ../../..; \
+	git clone -b rolling https://github.com/ros2/rosidl_core src/ros2/rosidl_core; \
+	git clone -b rolling https://github.com/ros2/rosidl_defaults src/ros2/rosidl_defaults; \
+	git clone -b rolling https://github.com/ros2/rosidl_dynamic_typesupport src/ros2/rosidl_dynamic_typesupport; \
+	git clone -b rolling https://github.com/ros2/test_interface_files src/ros2/test_interface_files; \
+	git clone -b rolling https://github.com/ros2/unique_identifier_msgs src/ros2/unique_identifier_msgs; \
+	set -e; \
+	rm -r src/micro-ROS/rcl/rcl_lifecycle; \
+	rm -r src/micro-ROS/rcl/rcl_yaml_param_parser; \
+	rm -r src/micro-ROS/rosidl_typesupport/rosidl_typesupport_tests; \
+	rm -r src/micro-ROS/rosidl_typesupport_microxrcedds/test; \
+	rm -r src/ros2/common_interfaces/common_interfaces; \
+	rm -r src/ros2/common_interfaces/sensor_msgs_py; \
+	rm -r src/ros2/rcl_logging/rcl_logging_implementation; \
+	rm -r src/ros2/rcl_logging/rcl_logging_spdlog; \
+	rm -r src/ros2/rclc/rclc_examples; \
+	rm -r src/ros2/rclc/rclc_lifecycle; \
+	rm -r src/ros2/rmw/rmw_security_common; \
+	rm -r src/ros2/rmw_implementation/test_rmw_implementation; \
+	rm -r src/ros2/ros2_tracing/lttngpy; \
+	rm -r src/ros2/ros2_tracing/ros2trace; \
+	rm -r src/ros2/ros2_tracing/test_ros2trace; \
+	rm -r src/ros2/ros2_tracing/test_tracetools; \
+	rm -r src/ros2/ros2_tracing/test_tracetools_launch; \
+	rm -r src/ros2/ros2_tracing/tracetools_launch; \
+	rm -r src/ros2/ros2_tracing/tracetools_read; \
+	rm -r src/ros2/ros2_tracing/tracetools_test; \
+	rm -r src/ros2/ros2_tracing/tracetools_trace; \
+	rm -r src/ros2/rosidl/rosidl_buffer; \
+	rm -r src/ros2/rosidl/rosidl_buffer_backend; \
+	rm -r src/ros2/rosidl/rosidl_buffer_backend_registry; \
+	rm -r src/ros2/rosidl/rosidl_generator_tests; \
+	rm -r src/ros2/rosidl/rosidl_typesupport_introspection_cpp; \
+	rm -r src/ros2/rosidl/rosidl_typesupport_introspection_tests; \
 	cp -rfL $(EXTRA_ROS_PACKAGES) src/extra_packages || :; \
 	test -f src/extra_packages/extra_packages.repos && cd src/extra_packages && vcs import --input extra_packages.repos || :;
 


### PR DESCRIPTION
This PR trims the current list of ROS 2 packages that are cloned and built to the ones that are truly needed.

`EXCLUDED_PACKAGES.md` documents what has been removed and why.

Instead of using COLCON_IGNORE files, we now delete unused packages with `rm -r` after cloning to avoid taking up space on the user's system. Clones also live under `src/<org>/<repo>` now, and both the clone and rm lists are sorted alphabetically.

`EXCLUDED_PACKAGES.md` is meant to include all packages that are in [`ros2.repos`](https://github.com/ros2/ros2/blob/rolling/ros2.repos) but aren't built here. It isn't fully up to date yet, and I will fix it in a future PR.