### PR TITLE
Fix ament_package build failing on older python versions

### DIFF
--- a/libmicroros.mk
+++ b/libmicroros.mk
@@ -35,6 +35,9 @@ $(EXTENSIONS_DIR)/micro_ros_dev/install:
 	git clone -b rolling https://github.com/ament/ament_cmake src/ament_cmake; \
 	git clone -b rolling https://github.com/ament/ament_lint src/ament_lint; \
 	git clone -b rolling https://github.com/ament/ament_package src/ament_package; \
+	cd src/ament_package; \
+	git apply ../../../remove-traversable.patch; \
+	cd ../../..; \
 	git clone -b rolling https://github.com/ament/googletest src/googletest; \
 	git clone -b rolling https://github.com/ros2/ament_cmake_ros src/ament_cmake_ros; \
 	git clone -b rolling https://github.com/ament/ament_index src/ament_index; \

--- a/remove-traversable.patch
+++ b/remove-traversable.patch
@@ -1,0 +1,43 @@
+diff --git a/ament_package/templates.py b/ament_package/templates.py
+index 41b0175..2db4fd5 100644
+--- a/ament_package/templates.py
++++ b/ament_package/templates.py
+@@ -13,18 +13,17 @@
+ # limitations under the License.
+ 
+ from importlib import resources
+-from importlib.resources.abc import Traversable
+ import os
+ import re
+ 
+ IS_WINDOWS = os.name == 'nt'
+ 
+ 
+-def _get_path(template: str, name: str) -> Traversable:
++def _get_path(template: str, name: str):
+     return resources.files(template).joinpath(name)
+ 
+ 
+-def get_environment_hook_template_path(name: str) -> Traversable:
++def get_environment_hook_template_path(name: str):
+     return _get_path('ament_package.template.environment_hook', name)
+ 
+ 
+@@ -41,7 +40,7 @@ def get_package_level_template_names(all_platforms: bool = False) -> list[str]:
+     return names
+ 
+ 
+-def get_package_level_template_path(name: str) -> Traversable:
++def get_package_level_template_path(name: str):
+     return _get_path('ament_package.template.package_level', name)
+ 
+ 
+@@ -61,7 +60,7 @@ def get_prefix_level_template_names(*, all_platforms: bool = False) -> list[str]
+     return names
+ 
+ 
+-def get_prefix_level_template_path(name: str) -> Traversable:
++def get_prefix_level_template_path(name: str):
+     return _get_path('ament_package.template.prefix_level', name)
+ 
+ 


### PR DESCRIPTION
I have added a patch file to the codebase that should help fix #371 by removing the `Traversable` import and its usage.
It's a bit different from the solutions suggested in #371, but I feel like this is the most maintainable way to do it.